### PR TITLE
Add a check if debugon is "false" and treat as false

### DIFF
--- a/lib/nexmo.js
+++ b/lib/nexmo.js
@@ -69,7 +69,7 @@ exports.initialize = function(pkey, psecret, protocol, debugon) {
         api_secret: psecret
     }
     useHttps = protocol && protocol == 'https'; // default to http
-    debugOn = debugon;
+    debugOn = debugon.toString() === "false" ? false : true;
     initialized = true;
 }
 


### PR DESCRIPTION
I was accidentally dynamically generating a config with "false"
instead of false. I thought it might be nifty if that didn't mess
things up.
