### PR TITLE
HTTP Client Object and User Agent

### DIFF
--- a/src/Account.js
+++ b/src/Account.js
@@ -17,7 +17,7 @@ class Account {
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
     
-    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
+    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options);
   }
   
   /**

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ class App {
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
     
-    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
+    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options);
   }
   
   /**

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -1,0 +1,85 @@
+var https = require('https');
+var http = require('http');
+
+var headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'accept': 'application/json'
+};
+
+class HttpClient {
+  constructor(options) {
+    this.port = 443 || options.port;
+    this.https = options.https || https;
+    this.http =  options.http || http;
+    this.log = options.log || function() {};
+  }
+  
+  request(endpoint, method, callback) {
+    if (typeof method == 'function') {
+        callback = method;
+        method = 'GET';
+    }
+    if (method == 'POST' || method == 'DELETE') {
+        // TODO: verify the following fix is required
+        // Fix broken due ot 411 Content-Length error now sent by Nexmo API
+        // PL 2016-Sept-6 - commented out Content-Length 0
+        // headers['Content-Length'] = 0;
+    }
+    var options = {
+        host: endpoint.host?endpoint.host:'rest.nexmo.com',
+        port: this.port,
+        path: endpoint.path,
+        method: method,
+        headers: headers
+    };
+    this.log(options);
+    var request;
+  	if (true) { // set to false to verify the request without sending the actual request
+        if (options.port == 443) {
+            request = this.https.request(options);
+        } else {
+            request = http.request(options);
+        }
+  	    request.end();
+  	    var responseReturn = '';
+  	    request.on('response', (response) => {
+  	        response.setEncoding('utf8');
+  	        response.on('data', (chunk) => {
+  	            responseReturn += chunk;
+  	        });
+  	        response.on('end', () => {
+  	            this.log('response ended');
+  	            if (callback) {
+  	                var retJson = responseReturn;
+  	                var err = null;
+                    if (method !== 'DELETE') {
+                      try {
+    	                    retJson = JSON.parse(responseReturn);
+    	                } catch (parsererr) {
+    	                    // ignore parser error for now and send raw response to client
+    	                    this.log(parsererr);
+    	                    this.log('could not convert API response to JSON, above error is ignored and raw API response is returned to client');
+    						          this.log('Raw Error message from API ');
+    						          this.log(responseReturn);
+    	                    err = parsererr;
+    	                }
+                    }
+                    callback(err, retJson);
+  	            }
+  	        })
+  	        response.on('close', (e) => {
+  	            this.log('problem with API request detailed stacktrace below ');
+  	            this.log(e);
+  	            callback(e);
+  	        });
+  	    });
+  	    request.on('error', (e) => {
+  	        this.log('problem with API request detailed stacktrace below ');
+  	        this.log(e);
+  	        callback(e);
+  	    });
+  	}
+  }
+}
+
+module.exports = HttpClient;

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -12,6 +12,11 @@ class HttpClient {
     this.https = options.https || https;
     this.http =  options.http || http;
     this.log = options.log || function() {};
+    this.headers = headers;
+    
+    if(options.userAgent) {
+      this.headers['User-Agent'] = options.userAgent;
+    }
   }
   
   request(endpoint, method, callback) {
@@ -30,7 +35,7 @@ class HttpClient {
         port: this.port,
         path: endpoint.path,
         method: method,
-        headers: headers
+        headers: this.headers
     };
     this.log(options);
     var request;

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -3,7 +3,7 @@ var http = require('http');
 
 var headers = {
     'Content-Type': 'application/x-www-form-urlencoded',
-    'accept': 'application/json'
+    'Accept': 'application/json'
 };
 
 class HttpClient {

--- a/src/Message.js
+++ b/src/Message.js
@@ -16,7 +16,7 @@ class Message {
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
     
-    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
+    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options);
   }
   
   /**

--- a/src/Nexmo.js
+++ b/src/Nexmo.js
@@ -12,7 +12,10 @@ class Nexmo {
    * @param {Credentials} credentials - Nexmo API credentials
    * @param {string} credentials.apiKey - the Nexmo API key
    * @param {string} credentials.apiSecret - the Nexmo API secret
-   * @param {object} options Additional options
+   * @param {Object} options Additional options
+   * @param {boolean} options.debug `true` to turn on debug logging
+   * @param {string} options.appendToUserAgent A value to append to the user agent.
+   *                    The value will be prefixed with a `/`
    */
   constructor(credentials, options) {
     this._credentials = Credentials.parse(credentials);

--- a/src/Number.js
+++ b/src/Number.js
@@ -17,7 +17,7 @@ class Number {
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
     
-    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
+    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options);
   }
   
   /**

--- a/src/NumberInsight.js
+++ b/src/NumberInsight.js
@@ -17,7 +17,7 @@ class NumberInsight {
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
     
-    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
+    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options);
   }
   
   /**

--- a/src/Verify.js
+++ b/src/Verify.js
@@ -17,7 +17,7 @@ class Verify {
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
     
-    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
+    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options);
   }
   
   /**

--- a/src/Voice.js
+++ b/src/Voice.js
@@ -16,7 +16,7 @@ class Voice {
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
     
-    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
+    this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options);
   }
   
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ function sendRequest(endpoint, method, callback) {
   endpoint.path = endpoint.path +
                   (endpoint.path.indexOf('?')>0?'&':'?') + 
                   querystring.stringify(up);
-  var client = new HttpClient({log: log}, {userAgent: USER_AGENT});
+  var client = new HttpClient({log: log, userAgent: USER_AGENT});
   client.request(endpoint, method, callback);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,9 @@
 'use strict';
 
-var https = require('https');
-var http = require('http');
+var HttpClient = require('./HttpClient');
 var querystring = require('querystring');
 
-var headers = {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    'accept': 'application/json'
-};
 var initialized = false;
-var username = '';
-var password = '';
 var msgpath = {host:'rest.nexmo.com',path:'/sms/json'};
 var shortcodePath = {host:'rest.nexmo.com',path:'/sc/us/${type}/json'};
 var ttsEndpoint = {host:'api.nexmo.com',path:'/tts/json'};
@@ -26,7 +19,6 @@ var niStandardEndpoint = {host:'api.nexmo.com',path:'/number/lookup/json'};
 var applicationsEndpoint = {host:'api.nexmo.com',path:'/beta/account/applications'};
 var up = {};
 var debugOn = false;
-var port = 443;
 var numberPattern = new RegExp("^[0-9 +()-]*$");
 
 //Error message resources are maintained globally in one place for easy management
@@ -67,8 +59,6 @@ exports.initialize = function(pkey, psecret, debugon) {
     if (!pkey || !psecret) {
         throw 'key and secret cannot be empty, set valid values';
     }
-    username = pkey;
-    password = psecret;
     up = {
         api_key: pkey,
         api_secret: psecret
@@ -194,69 +184,11 @@ function getEndpoint(action) {
 }
 
 function sendRequest(endpoint, method, callback) {
-    if (!initialized) {
-        throw 'nexmo not initialized, call nexmo.initialize(username, password) first before calling any nexmo API';
-    }
-    if (typeof method == 'function') {
-        callback = method;
-        method = 'GET';
-    }
-    if (method == 'POST' || method == 'DELETE')
-        headers['Content-Length'] = 0; // Fix broken due ot 411 Content-Length error now sent by Nexmo API
-    var options = {
-        host: endpoint.host?endpoint.host:'rest.nexmo.com',
-        port: port,
-        path: endpoint.path + (endpoint.path.indexOf('?')>0?'&':'?') + querystring.stringify(up),
-        method: method,
-        headers: headers
-    };
-    log(options);
-    var request;
-	if (true) { // set to false to verify the request without sending the actual request
-      if (options.port == 443) {
-          request = https.request(options);
-      } else {
-          request = http.request(options);
-      }
-	    request.end();
-	    var responseReturn = '';
-	    request.on('response', function(response) {
-	        response.setEncoding('utf8');
-	        response.on('data', function(chunk) {
-	            responseReturn += chunk;
-	        });
-	        response.on('end', function() {
-	            log('response ended');
-	            if (callback) {
-	                var retJson = responseReturn;
-	                var err = null;
-                  if (method !== 'DELETE') {
-                    try {
-  	                    retJson = JSON.parse(responseReturn);
-  	                } catch (parsererr) {
-  	                    // ignore parser error for now and send raw response to client
-  	                    log(parsererr);
-  	                    log('could not convert API response to JSON, above error is ignored and raw API response is returned to client');
-  						          log('Raw Error message from API ');
-  						          log(responseReturn);
-  	                    err = parsererr;
-  	                }
-                  }
-                  callback(err, retJson);
-	            }
-	        })
-	        response.on('close', function(e) {
-	            log('problem with API request detailed stacktrace below ');
-	            log(e);
-	            callback(e);
-	        });
-	    });
-	    request.on('error', function(e) {
-	        log('problem with API request detailed stacktrace below ');
-	        log(e);
-	        callback(e);
-	    });
-	}
+  endpoint.path = endpoint.path +
+                  (endpoint.path.indexOf('?')>0?'&':'?') + 
+                  querystring.stringify(up);
+  var client = new HttpClient({log: log});
+  client.request(endpoint, method, callback);
 }
 
 exports.checkBalance = function(callback) {

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -127,5 +127,29 @@ describe('HttpClient Object', function () {
     
     expect(logged).to.be(true);
   });
+  
+  it('should allow User-Agent header to be set via options', function() {
+    var expectedUserAgeint = 'nexmo-node/1.0.0/v4.4.7';
+    
+    var mock = sinon.mock(fakeHttp);
+    mock.expects('request')
+      .once()
+      .withArgs({
+        headers:{
+          "Content-Type": "application/x-www-form-urlencoded",
+          "accept": "application/json",
+          "User-Agent": expectedUserAgeint
+        },
+        host: "api.nexmo.com",
+        method: "POST",
+        path: "/api",
+        port: 443
+      })
+      .returns(fakeRequest);
+    
+    var client = new HttpClient({https:fakeHttp, userAgent: expectedUserAgeint});
+    
+    client.request({host:'api.nexmo.com', path: '/api'}, 'POST', {some: 'data'});
+  });
 
 });

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -1,0 +1,131 @@
+import sinon from 'sinon';
+import expect from 'expect.js';
+
+import https from 'https';
+import http from 'http';
+
+import HttpClient from '../lib/HttpClient';
+
+var fakeHttp = {request: function() {}};
+var fakeRequest = {
+  end: function(){},
+  on: function(){}
+};
+
+var defaultHeaders = {
+  "Content-Type": "application/x-www-form-urlencoded",
+  "accept": "application/json"
+};
+
+describe('HttpClient Object', function () {
+  
+  afterEach(function() {
+    fakeHttp.request.restore();
+  });
+  
+  it('should support GET requests over https', function() {
+    var mock = sinon.mock(fakeHttp);
+    mock.expects('request')
+      .once()
+      .withArgs({
+        headers: defaultHeaders,
+        host: "api.nexmo.com",
+        method: "GET",
+        path: "/api",
+        port: 443
+      })
+      .returns(fakeRequest);
+    
+    var client = new HttpClient({https:fakeHttp, port:443});
+    
+    client.request({host:'api.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
+  });
+  
+  it('should support GET requests over http', function() {
+    var mock = sinon.mock(fakeHttp);
+    mock.expects('request')
+      .once()
+      .withArgs({
+        headers: defaultHeaders,
+        host: "api.nexmo.com",
+        method: "GET",
+        path: "/api",
+        port: 80
+      })
+      .returns(fakeRequest);
+    
+    var client = new HttpClient({http:fakeHttp, port:80});
+    
+    client.request({host:'api.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
+  });
+  
+  it('should be possible to set the host', function() {
+    var mock = sinon.mock(fakeHttp);
+    mock.expects('request')
+      .once()
+      .withArgs({
+        headers: defaultHeaders,
+        host: "rest.nexmo.com",
+        method: "GET",
+        path: "/api",
+        port: 80
+      })
+      .returns(fakeRequest);
+    
+    var client = new HttpClient({http:fakeHttp, port:80});
+    
+    client.request({host:'rest.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
+  });
+  
+  it('should be possible to set the path', function() {
+    var mock = sinon.mock(fakeHttp);
+    mock.expects('request')
+      .once()
+      .withArgs({
+        headers: defaultHeaders,
+        host: "api.nexmo.com",
+        method: "GET",
+        path: "/some_path",
+        port: 80
+      })
+      .returns(fakeRequest);
+    
+    var client = new HttpClient({http:fakeHttp, port:80});
+    
+    client.request({host:'api.nexmo.com', path: '/some_path'}, 'GET', {some: 'data'});
+  });
+  
+  it('should be possible to set the method', function() {
+    var mock = sinon.mock(fakeHttp);
+    mock.expects('request')
+      .once()
+      .withArgs({
+        headers: defaultHeaders,
+        host: "api.nexmo.com",
+        method: "POST",
+        path: "/api",
+        port: 443
+      })
+      .returns(fakeRequest);
+    
+    var client = new HttpClient({https:fakeHttp});
+    
+    client.request({host:'api.nexmo.com', path: '/api'}, 'POST', {some: 'data'});
+  });
+  
+  it('should log requests', function() {
+    var mock = sinon.mock(fakeHttp);
+    mock.expects('request').returns(fakeRequest);
+    
+    var logged = false;
+    var log = function() {
+      logged = true;
+    }
+    var client = new HttpClient({https:fakeHttp, log:log});
+    
+    client.request({host:'api.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
+    
+    expect(logged).to.be(true);
+  });
+
+});

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -23,7 +23,7 @@ describe('HttpClient Object', function () {
     fakeHttp.request.restore();
   });
   
-  it('should support GET requests over https', function() {
+  it('should support requests over https', function() {
     var mock = sinon.mock(fakeHttp);
     mock.expects('request')
       .once()
@@ -41,7 +41,7 @@ describe('HttpClient Object', function () {
     client.request({host:'api.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
   });
   
-  it('should support GET requests over http', function() {
+  it('should support requests over http', function() {
     var mock = sinon.mock(fakeHttp);
     mock.expects('request')
       .once()

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -129,7 +129,7 @@ describe('HttpClient Object', function () {
   });
   
   it('should allow User-Agent header to be set via options', function() {
-    var expectedUserAgeint = 'nexmo-node/1.0.0/v4.4.7';
+    var expectedUserAgent = 'nexmo-node/1.0.0/v4.4.7';
     
     var mock = sinon.mock(fakeHttp);
     mock.expects('request')
@@ -138,7 +138,7 @@ describe('HttpClient Object', function () {
         headers:{
           "Content-Type": "application/x-www-form-urlencoded",
           "accept": "application/json",
-          "User-Agent": expectedUserAgeint
+          "User-Agent": expectedUserAgent
         },
         host: "api.nexmo.com",
         method: "POST",
@@ -147,7 +147,7 @@ describe('HttpClient Object', function () {
       })
       .returns(fakeRequest);
     
-    var client = new HttpClient({https:fakeHttp, userAgent: expectedUserAgeint});
+    var client = new HttpClient({https:fakeHttp, userAgent: expectedUserAgent});
     
     client.request({host:'api.nexmo.com', path: '/api'}, 'POST', {some: 'data'});
   });

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -14,7 +14,7 @@ var fakeRequest = {
 
 var defaultHeaders = {
   "Content-Type": "application/x-www-form-urlencoded",
-  "accept": "application/json"
+  "Accept": "application/json"
 };
 
 describe('HttpClient Object', function () {
@@ -137,7 +137,7 @@ describe('HttpClient Object', function () {
       .withArgs({
         headers:{
           "Content-Type": "application/x-www-form-urlencoded",
-          "accept": "application/json",
+          "Accept": "application/json",
           "User-Agent": expectedUserAgent
         },
         host: "api.nexmo.com",

--- a/test/Nexmo-test.js
+++ b/test/Nexmo-test.js
@@ -1,5 +1,6 @@
 import Nexmo from '../lib/Nexmo';
 import expect from 'expect.js'
+import sinon from 'sinon';
 
 describe('Nexmo Object instance', function () {
   
@@ -36,6 +37,42 @@ describe('Nexmo Object instance', function () {
   it('should expose a account object', function () {
     var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
     expect(nexmo.account).to.be.a('object');
+  });
+  
+  it('should allow options to be passed', function () {
+    var initializedSpy = sinon.spy();
+    var options = {
+      nexmoOverride: {
+        initialize: initializedSpy
+      },
+      appendToUserAgent: 'EXT',
+      debug: true
+    };
+    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'}, options);
+    expect( initializedSpy.calledWith('test', 'test', options) ).to.be.ok();
+  });
+
+  it('should have debug turned off by default', function () {
+    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
+    expect( nexmo.message._nexmo._getDebug() ).to.be(false);
+  });
+
+  it('should allow a debug option to be set', function () {
+    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'}, { debug: true });
+    expect( nexmo.message._nexmo._getDebug() ).to.be(true);
+  });
+  
+  it('should have a default user agent in the form LIBRARY-NAME/LIBRARY-VERSION/LANGUAGE-VERSION', function () {
+    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
+    expect( nexmo.message._nexmo._getUserAgent() ).to.match(/.*\/.*\/.*$/);
+  });
+
+  it('should append to the user agent when a appendToUserAgent option is passed', function () {
+    var options = {
+      appendToUserAgent: 'EXT'
+    };
+    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'}, options);
+    expect( nexmo.message._nexmo._getUserAgent() ).to.match(/\/EXT$/);
   });
   
 });


### PR DESCRIPTION
- Move HTTP functionality into an `HttpClient` object
- Default `User-Agent` header is now set to meet the [spec criteria](https://github.com/Nexmo/client-library-specification/blob/master/SPECIFICATION.md#reporting)
- Ability to append information to the `User-Agent` via the `Nexmo` constructor `options.appendToUserAgent` property

For the Http Client refactoring there is still some querystring manipulation going on in the `index.js` global, but this hopefully represents reasonable progress.
