### PR TITLE
Replace NI Advanced call with synchronous version

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ nexmo.numberInsight.get({level: 'basic', number: '1-234-567-8900'}, consolelog);
 ```js
 nexmo.numberInsight.get({level: 'standard', number: NUMBER}, callback);
 ```
-	
+
 For more information check the documentation at https://docs.nexmo.com/number-insight/standard
 
 Example:
@@ -251,10 +251,17 @@ nexmo.numberInsight.get({level: 'standard', number: '1-234-567-8900'}, consolelo
 ### Number Insight - Advanced
 
 ```js
-nexmo.numberInsight.get({level: 'advanced', number: NUMBER}, callback);
+nexmo.numberInsight.get({level: 'advanced', number: NUMBER}, consolelog);
 ```
 
 For more information check the documentation at https://docs.nexmo.com/number-insight/advanced
+
+As the advanced call can take a few seconds to complete there is an asynchronous option that will instead make a webhook to a specified URL.
+
+
+```js
+nexmo.numberInsight.get({level: 'asyncAdvanced', number: NUMBER, callback: "http://example.com"}, consolelog);
+```
 
 ## Callbacks
 

--- a/src/NumberInsight.js
+++ b/src/NumberInsight.js
@@ -3,7 +3,7 @@
 import nexmo from './index';
 
 class NumberInsight {
-  
+
   /**
    * @param {Credentials} credentials
    *    credentials to be used when interacting with the API.
@@ -13,13 +13,13 @@ class NumberInsight {
   constructor(credentials, options = {}) {
     this.creds = credentials;
     this.options = options;
-    
+
     // Used to facilitate testing of the call to the underlying object
     this._nexmo = this.options.nexmoOverride || nexmo;
-    
+
     this._nexmo.initialize(this.creds.apiKey, this.creds.apiSecret, this.options.debug);
   }
-  
+
   /**
    * Get insight on the provided number.
    *
@@ -33,55 +33,59 @@ class NumberInsight {
    *                 An ISO 3166 Alpha 2 country code
    *                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
    * @param {string} options. ip - 'advanced' only.
-   *                 The IP address in IPv4 notation of the endpoint the 
+   *                 The IP address in IPv4 notation of the endpoint the
    *                 user connected from.
    * @param {Array}  options.features - 'advanced' only.
-   *                 An Array detailing the information you want for this phone 
+   *                 An Array detailing the information you want for this phone
    *                 number. Possible Array elements are:
    *                 - type: number is one of the following: mobile, landline,
    *                          landline_premium or unknown phone number.
    *                 - valid: number exists.
    *                 - reachable: is number available now.
    *                 - carrier: the MCCMNC for the carrier number is registered
-   *                             with. This is either: <ISO country code>-FIXED 
+   *                             with. This is either: <ISO country code>-FIXED
    *                             or <ISO country code>-PREMIUM.
    *                 - ported: if the user has changed carrier for number.
    *                 - roaming: the subscriber is outside their home network
-   * 
+   *
    * @param {string} options.callback - 'advanced' only.
    *                 The callback to be called when the API call completes.
    * @param {Number} options.callback_timeout - 'advanced' only.
    *                 The maximum wait until the Number Insight Return Parameters
-   *                 are sent to callback. This is a value between 1000 - 30000ms 
+   *                 are sent to callback. This is a value between 1000 - 30000ms
    *                 inclusive. The default is 30000 ms.
    * @param {string} options.callback_method - 'advanced' only.
-   *                 The HTTP method used to send the Number Insight Return 
-   *                 Parameters to callback. Must be GET or POST. The default 
+   *                 The HTTP method used to send the Number Insight Return
+   *                 Parameters to callback. Must be GET or POST. The default
    *                 value is GET.
    * @param {string} options.client_ref - 'advanced' only.
-   *                 A 40 character reference string returned in the Number 
-   *                 Insight Return Parameters. This may be useful for your 
+   *                 A 40 character reference string returned in the Number
+   *                 Insight Return Parameters. This may be useful for your
    *                 internal reports.
    * @param {string} options['include-intermediate-callbacks'] - 'advanced' only.
-   *                 Tells the Nexmo platform to make callbacks as soon as an 
+   *                 Tells the Nexmo platform to make callbacks as soon as an
    *                 individual piece of information is retrieved.
    */
   get(options, callback) {
     var level = options.level;
     // remove 'level' as it's a library-only parameter
     delete options.level;
-    
+
     if(level === 'advanced') {
+      this._nexmo.numberInsightAdvanced.apply(this._nexmo, arguments);
+    } else if (level === 'asyncAdvanced') {
       this._nexmo.numberInsight.apply(this._nexmo, arguments);
     }
     else if(level === 'standard') {
+      console.log('3');
       this._nexmo.numberInsightStandard.apply(this._nexmo, arguments);
     }
     else {
+      console.log('4');
       this._nexmo.numberInsightBasic.apply(this._nexmo, arguments);
     }
   }
-  
+
 }
 
 export default NumberInsight;

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,9 @@ var checkVerifyEndpoint = {host:'api.nexmo.com',path:'/verify/check/json'};
 var controlVerifyEndpoint = {host:'api.nexmo.com',path:'/verify/control/json'};
 var searchVerifyEndpoint = {host:'api.nexmo.com',path:'/verify/search/json'};
 var niEndpoint = {host:'rest.nexmo.com',path:'/ni/json'};
-var niBasicEndpoint = {host:'api.nexmo.com',path:'/number/format/json'};
-var niStandardEndpoint = {host:'api.nexmo.com',path:'/number/lookup/json'};
+var niBasicEndpoint = {host:'api.nexmo.com',path:'/ni/advanced/async/json'};
+var niStandardEndpoint = {host:'api.nexmo.com',path:'/ni/standard/json'};
+var niAdvancedEndpoint = {host:'api.nexmo.com',path:'/ni/advanced/json'};
 var applicationsEndpoint = {host:'api.nexmo.com',path:'/beta/account/applications'};
 var up = {};
 var debugOn = false;
@@ -523,13 +524,7 @@ exports.searchVerifyRequest = function(requestIds, callback) {
 }
 
 exports.numberInsight = function(inputParams, callback) {
-	if (!inputParams.number || ! inputParams.callback) {
-		sendError(callback, new Error(ERROR_MESSAGES.numberInsightAdvancedValidation));
-    } else {
-		var nEndpoint = clone(niEndpoint);
-		nEndpoint.path += '?' + querystring.stringify(inputParams);
-        sendRequest(nEndpoint, callback);
-    }
+	numberInsightAsync(inputParams, callback);
 }
 
 exports.numberInsightBasic = function(inputParams, callback) {
@@ -538,6 +533,24 @@ exports.numberInsightBasic = function(inputParams, callback) {
 
 exports.numberInsightStandard = function(inputParams, callback) {
 	numberInsightCommon(niStandardEndpoint,inputParams,callback)
+}
+
+exports.numberInsightAdvanced = function(inputParams, callback) {
+	numberInsightCommon(niAdvancedEndpoint,inputParams,callback)
+}
+
+exports.numberInsightAdvancedAsync = function(inputParams, callback) {
+  numberInsightAsync(inputParams, callback);
+}
+
+function numberInsightAsync(inputParams, callback) {
+  if (!inputParams.number || ! inputParams.callback) {
+		sendError(callback, new Error(ERROR_MESSAGES.numberInsightAdvancedValidation));
+    } else {
+		var nEndpoint = clone(niEndpoint);
+		nEndpoint.path += '?' + querystring.stringify(inputParams);
+        sendRequest(nEndpoint, callback);
+    }
 }
 
 function numberInsightCommon(endpoint,inputParams,callback) {

--- a/test/NumberInsight-test.js
+++ b/test/NumberInsight-test.js
@@ -3,19 +3,20 @@ import NumberInsight from '../lib/NumberInsight';
 import NexmoStub from './NexmoStub';
 
 var numberInsightAPIs = {
-  'numberInsight': 'get|{"level":"advanced"}',
+  'numberInsight': 'get|{"level":"asyncAdvanced"}',
+  'numberInsightAdvanced': 'get|{"level":"advanced"}',
   'numberInsightBasic': 'get|{"level":"basic"}',
   'numberInsightStandard': 'get|{"level":"standard"}'
 };
 
 describe('NumberInsight Object', function () {
-  
+
   it('should implement all v1 APIs', function() {
     NexmoStub.checkAllFunctionsAreDefined(numberInsightAPIs, NumberInsight);
   });
-  
+
   it('should proxy the function call to the underlying `nexmo` object', function() {
     NexmoStub.checkAllFunctionsAreCalled(numberInsightAPIs, NumberInsight);
   });
-  
+
 });


### PR DESCRIPTION
- Moved async call into own option
- Fixed all API endpoints to ones used in current docs
- Updated documentation to highlight changes

This will probably require a minor release bump as this commit will break for anyone expecting `nexmo.numberInsight.get({level: 'advanced'})` to be asynchronous.

Closes #64 
