### PR TITLE
Linted tests. Refactored tests to make linting pass.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+    'env': {
+        'es6': true,
+        'node': true,
+        'mocha': true,
+    },
+    'extends': 'eslint:recommended',
+    'parserOptions': {
+        'sourceType': 'module'
+    },
+    'rules': {
+        'indent': [
+            'error',
+            4
+        ],
+        'linebreak-style': [
+            'error',
+            'unix'
+        ],
+        'quotes': [
+            'error',
+            'single'
+        ],
+        'semi': [
+            'error',
+            'always'
+        ],
+        'no-console': [
+            'warn'
+        ],
+        'no-trailing-spaces': [
+          'error'
+        ],
+        'camelcase': [
+          'error'
+        ]
+    }
+};

--- a/.jslintrc
+++ b/.jslintrc
@@ -1,5 +1,0 @@
-{
-  "node": true,
-  "white": true,
-  "esversion": 6
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.11
+  - 0.12
+  - 4
+  - 5
+  - 6

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "body-parser": "^1.15.2",
     "chai": "^3.5.0",
     "dotenv": "^2.0.0",
-    "eslint": "^3.6.1",
+    "eslint": "^2",
     "expect.js": "^0.3.1",
     "express": "^4.14.0",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "compile": "./node_modules/.bin/babel -d lib src/ -s inline",
     "prepublish": "npm run compile",
     "test": "npm run compile && mocha --compilers ./node_modules/.bin/_mocha --compilers js:babel-register ./test/*-test.js",
-    "test-watch": "nodemon --watch src --watch test -x 'npm test'"
+    "test-watch": "nodemon --watch src --watch test -x 'npm test'",
+    "pretest": "eslint test"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
@@ -42,6 +43,7 @@
     "body-parser": "^1.15.2",
     "chai": "^3.5.0",
     "dotenv": "^2.0.0",
+    "eslint": "^3.6.1",
     "expect.js": "^0.3.1",
     "express": "^4.14.0",
     "mocha": "^2.4.5",

--- a/test/Account-test.js
+++ b/test/Account-test.js
@@ -3,20 +3,20 @@ import Account from '../lib/Account';
 import NexmoStub from './NexmoStub';
 
 var accountAPIs = {
-  'checkBalance': 'checkBalance',
-  'changePassword': 'updatePassword',
-  'changeMoCallbackUrl': 'updateSMSCallback',
-  'changeDrCallbackUrl': 'updateDeliveryReceiptCallback'
+    'checkBalance': 'checkBalance',
+    'changePassword': 'updatePassword',
+    'changeMoCallbackUrl': 'updateSMSCallback',
+    'changeDrCallbackUrl': 'updateDeliveryReceiptCallback'
 };
 
-describe('Account Object', function () {
-  
-  it('should implement all v1 APIs', function() {
-    NexmoStub.checkAllFunctionsAreDefined(accountAPIs, Account);
-  });
-  
-  it('should proxy the function call to the underlying `nexmo` object', function() {
-    NexmoStub.checkAllFunctionsAreCalled(accountAPIs, Account);
-  });
-  
+describe('Account Object', function() {
+
+    it('should implement all v1 APIs', function() {
+        NexmoStub.checkAllFunctionsAreDefined(accountAPIs, Account);
+    });
+
+    it('should proxy the function call to the underlying `nexmo` object', function() {
+        NexmoStub.checkAllFunctionsAreCalled(accountAPIs, Account);
+    });
+
 });

--- a/test/App-test.js
+++ b/test/App-test.js
@@ -6,37 +6,47 @@ import App from '../lib/App';
 import NexmoStub from './NexmoStub';
 
 var appAPIMapping = {
-  'getApplications':    'get|{}',
-  'createApplication':  'create',
-  'getApplication':     'get|someAppId',
-  'updateApplication':  'update',
-  'deleteApplication':  'delete'
+    'getApplications': 'get|{}',
+    'createApplication': 'create',
+    'getApplication': 'get|someAppId',
+    'updateApplication': 'update',
+    'deleteApplication': 'delete'
 };
 
-describe('App Object', function () {
-  
-  it('should implement all v1 APIs', function() {
-    NexmoStub.checkAllFunctionsAreDefined(appAPIMapping, App);
-  });
-  
-  it('should proxy the function call to the underlying `nexmo` object', function() {
-    NexmoStub.checkAllFunctionsAreCalled(appAPIMapping, App);
-  });
-  
-  it('should call nexmo.getApplications if 1st param is object', function() {
-    var mock = sinon.mock(nexmo);
-    mock.expects('getApplications').once();
-    
-    var app = new App({apiKey:'test', apiSecret:'test'}, {nexmoOverride: nexmo});
-    app.get({});
-  });
-  
-  it('should call nexmo.getApplication if 1st param is an app ID', function() {
-    var mock = sinon.mock(nexmo);
-    mock.expects('getApplication').once();
-    
-    var app = new App({apiKey:'test', apiSecret:'test'}, {nexmoOverride: nexmo});
-    app.get('some-app-id');
-  });
-  
+describe('App Object', function() {
+
+    it('should implement all v1 APIs', function() {
+        NexmoStub.checkAllFunctionsAreDefined(appAPIMapping, App);
+    });
+
+    it('should proxy the function call to the underlying `nexmo` object', function() {
+        NexmoStub.checkAllFunctionsAreCalled(appAPIMapping, App);
+    });
+
+    it('should call nexmo.getApplications if 1st param is object', function() {
+        var mock = sinon.mock(nexmo);
+        mock.expects('getApplications').once();
+
+        var app = new App({
+            apiKey: 'test',
+            apiSecret: 'test'
+        }, {
+            nexmoOverride: nexmo
+        });
+        app.get({});
+    });
+
+    it('should call nexmo.getApplication if 1st param is an app ID', function() {
+        var mock = sinon.mock(nexmo);
+        mock.expects('getApplication').once();
+
+        var app = new App({
+            apiKey: 'test',
+            apiSecret: 'test'
+        }, {
+            nexmoOverride: nexmo
+        });
+        app.get('some-app-id');
+    });
+
 });

--- a/test/CallResource-test.js
+++ b/test/CallResource-test.js
@@ -1,12 +1,12 @@
-import chai, { expect } from 'chai';
-import sinon            from 'sinon';
-import sinonChai        from 'sinon-chai';
+import chai, {
+    expect
+} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
 import ResourceTestHelper from './ResourceTestHelper';
-
-import querystring from 'querystring';
 
 import CallsResource from '../lib/CallsResource';
 import StreamResource from '../lib/StreamResource';
@@ -16,120 +16,124 @@ import HttpClient from '../lib/HttpClient';
 import Credentials from '../lib/Credentials';
 
 var creds = Credentials.parse({
-  applicationId: 'some-id',
-  privateKey: __dirname + '/private-test.key'
+    applicationId: 'some-id',
+    privateKey: __dirname + '/private-test.key'
 });
 var emptyCallback = () => {};
 
 describe('CallsResource', () => {
-  
-  var httpClientStub = null;
-  var calls = null;
-  
-  beforeEach(() => {
-    httpClientStub = sinon.createStubInstance(HttpClient);
-    var options = {
-      httpClient: httpClientStub
-    };
-    calls = new CallsResource(creds, options);
-  })
-  
-  it('should allow a call to be created', () => {
-    var params = {};
-    calls.create(params, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params);
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
 
-  it('should throw an error if no query is provided', () => {
-    var expectThrow = function(){
-      calls.get();
-    };
-    
-    expect(expectThrow).to.throw(Error);
-  });
-  
-  it('should get a collection of calls', () => {
-    calls.get({}, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
-      method: 'GET',
-      body: undefined,
-      path: `${CallsResource.PATH}`
-    });
-    
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
-  it('should get a single of call using a call ID', () => {
-    const callId = '2342342-lkjhlkjh-32423';
-    calls.get(callId, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
-      method: 'GET',
-      body: undefined,
-      path: `${CallsResource.PATH}/${callId}`
-    });
-    
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
-  it('should get a allow calls to be queried by filter', () => {
-    calls.get({status: 'answered'}, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
-      method: 'GET',
-      body: undefined,
-      path: `${CallsResource.PATH}?status=answered`
-    });
-    
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
+    var httpClientStub = null;
+    var calls = null;
 
-  it('should allow a call to be updated', () => {
-    const callId = '2342342-lkjhlkjh-32423';
-    var params = {action: 'hangup'};
-    calls.update(callId, params, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
-      method: 'PUT',
-      path: `${CallsResource.PATH}/${callId}`
+    beforeEach(() => {
+        httpClientStub = sinon.createStubInstance(HttpClient);
+        var options = {
+            httpClient: httpClientStub
+        };
+        calls = new CallsResource(creds, options);
     });
-    
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
-  it('should expose a stream property', () => {
-    expect(calls.stream).to.be.an.instanceOf(StreamResource);
-  });
-  
-  it('should expose a talk property', () => {
-    expect(calls.talk).to.be.an.instanceOf(TalkResource);
-  });
-  
-  it('should expose a dtmf property', () => {
-    expect(calls.dtmf).to.be.an.instanceOf(DtmfResource);
-  });
-  
+
+    it('should allow a call to be created', () => {
+        var params = {};
+        calls.create(params, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params);
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
+    it('should throw an error if no query is provided', () => {
+        var expectThrow = function() {
+            calls.get();
+        };
+
+        expect(expectThrow).to.throw(Error);
+    });
+
+    it('should get a collection of calls', () => {
+        calls.get({}, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
+            method: 'GET',
+            body: undefined,
+            path: `${CallsResource.PATH}`
+        });
+
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
+    it('should get a single of call using a call ID', () => {
+        const callId = '2342342-lkjhlkjh-32423';
+        calls.get(callId, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
+            method: 'GET',
+            body: undefined,
+            path: `${CallsResource.PATH}/${callId}`
+        });
+
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
+    it('should get a allow calls to be queried by filter', () => {
+        calls.get({
+            status: 'answered'
+        }, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
+            method: 'GET',
+            body: undefined,
+            path: `${CallsResource.PATH}?status=answered`
+        });
+
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
+    it('should allow a call to be updated', () => {
+        const callId = '2342342-lkjhlkjh-32423';
+        var params = {
+            action: 'hangup'
+        };
+        calls.update(callId, params, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
+            method: 'PUT',
+            path: `${CallsResource.PATH}/${callId}`
+        });
+
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
+    it('should expose a stream property', () => {
+        expect(calls.stream).to.be.an.instanceOf(StreamResource);
+    });
+
+    it('should expose a talk property', () => {
+        expect(calls.talk).to.be.an.instanceOf(TalkResource);
+    });
+
+    it('should expose a dtmf property', () => {
+        expect(calls.dtmf).to.be.an.instanceOf(DtmfResource);
+    });
+
 });

--- a/test/ConsoleLogger-test.js
+++ b/test/ConsoleLogger-test.js
@@ -1,64 +1,66 @@
-import chai, { expect } from 'chai';
-import sinon            from 'sinon';
-import sinonChai        from 'sinon-chai';
+import chai, {
+    expect
+} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
 import ConsoleLogger from '../lib/ConsoleLogger';
 
 describe('ConsoleLogger', () => {
-  
-  describe('.log', () => {
 
-    it('should log `info` using `console.log`', () => {
-      var fakeConsole = {
-        log: () => {}
-      };
-      var stub = sinon.stub(fakeConsole);
-      
-      var logger = new ConsoleLogger(stub);
-      logger.info('something');
-      
-      expect(stub.log).to.have.been.calledWith('info:', 'something');
+    describe('.log', () => {
+
+        it('should log `info` using `console.log`', () => {
+            var fakeConsole = {
+                log: () => {}
+            };
+            var stub = sinon.stub(fakeConsole);
+
+            var logger = new ConsoleLogger(stub);
+            logger.info('something');
+
+            expect(stub.log).to.have.been.calledWith('info:', 'something');
+        });
+
+        it('should log `error` using `console.error`', () => {
+            var fakeConsole = {
+                error: () => {}
+            };
+            var stub = sinon.stub(fakeConsole);
+
+            var logger = new ConsoleLogger(stub);
+            logger.error('an error');
+
+            expect(stub.error).to.have.been.calledWith('error:', 'an error');
+        });
+
+        it('should log `warn` using `console.log`', () => {
+            var fakeConsole = {
+                log: () => {}
+            };
+            var stub = sinon.stub(fakeConsole);
+
+            var logger = new ConsoleLogger(stub);
+            logger.warn('a warning');
+
+            expect(stub.log).to.have.been.calledWith('warn:', 'a warning');
+        });
+
+
+        it('should log levels using `console.log`', () => {
+            var fakeConsole = {
+                log: () => {}
+            };
+            var stub = sinon.stub(fakeConsole);
+
+            var logger = new ConsoleLogger(stub);
+            logger.log('silly', 'something silly');
+
+            expect(stub.log).to.have.been.calledWith('silly:', 'something silly');
+        });
+
     });
-    
-    it('should log `error` using `console.error`', () => {
-      var fakeConsole = {
-        error: () => {}
-      };
-      var stub = sinon.stub(fakeConsole);
-      
-      var logger = new ConsoleLogger(stub);
-      logger.error('an error');
-      
-      expect(stub.error).to.have.been.calledWith('error:', 'an error');
-    });    
-    
-    it('should log `warn` using `console.log`', () => {
-      var fakeConsole = {
-        log: () => {}
-      };
-      var stub = sinon.stub(fakeConsole);
-      
-      var logger = new ConsoleLogger(stub);
-      logger.warn('a warning');
-      
-      expect(stub.log).to.have.been.calledWith('warn:', 'a warning');
-    });
-    
-    
-    it('should log levels using `console.log`', () => {
-      var fakeConsole = {
-        log: () => {}
-      };
-      var stub = sinon.stub(fakeConsole);
-      
-      var logger = new ConsoleLogger(stub);
-      logger.log('silly', 'something silly');
-      
-      expect(stub.log).to.have.been.calledWith('silly:', 'something silly');
-    });
-    
-  });
-  
+
 });

--- a/test/Credentials-test.js
+++ b/test/Credentials-test.js
@@ -1,6 +1,8 @@
-import chai, { expect } from 'chai';
-import sinon            from 'sinon';
-import sinonChai        from 'sinon-chai';
+import chai, {
+    expect
+} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
@@ -8,69 +10,74 @@ import JwtGenerator from '../lib/JwtGenerator';
 
 import Credentials from '../lib/Credentials';
 
-describe('Credentials Object', function () {
-  
-  it('should be possible to construct a Credential object', function() {
-    var cred = Credentials.parse('KEY', 'SECRET');
-    
-    expect(cred).to.be.an.instanceof(Credentials);
-  });
-  
-  it('should parse object literal into a Credential object', function() {
-    var key = 'KEY';
-    var secret = 'SECRET';
-    var appId = 'app-id';
-    var privateKey = __dirname + '/private-test.key';
-    var obj = {apiKey: key, apiSecret: secret, applicationId: appId, privateKey: privateKey};
-    var parsed = Credentials.parse(obj);
-    
-    expect(parsed).to.be.an.instanceof(Credentials);
-    expect(parsed.apiKey).to.be.equal(key);
-    expect(parsed.apiSecret).to.be.equal(secret);
-    expect(parsed.applicationId).to.be.equal(appId);
-    expect(parsed.privateKey).to.be.ok;
-  });
-  
-  it('should throw an error when a privateKey is provided and the file does not exist', function() {
-    var create = function() {
-      new Credentials('KEY', 'SECRET', './no-key-here.key');
-    };
-    expect(create).to.throw(Error);
-  });
-  
-  
-  it('should read a private key into a Buffer accessible via Credentials.privateKey', function() {
-    var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key');
-    expect(cred.privateKey).to.be.an.instanceof(Buffer);
-  });
-  
-  it('should allow an applicationId to be provided upon construction', function() {
-    var appId = 'some_app_id';
-    var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key', appId);
-    expect(cred.applicationId).to.equal(appId);
-  });
-  
-  it('should allow a JWT to be generated using supplied application ID', function() {
-    var stub = sinon.createStubInstance(JwtGenerator)
-    
-    var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key', 'app-id');
-    cred._setJwtGenerator(stub);
-    
-    var token = cred.generateJwt();
-    
-    expect(stub.generate).to.be.calledWith(cred.privateKey, cred.applicationId);
-  });
-  
-  it('should allow a JWT to be generated using an alternative application ID', function() {
-    var stub = sinon.createStubInstance(JwtGenerator)
-    
-    var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key', 'app-id');
-    cred._setJwtGenerator(stub);
-    
-    var altAppId = 'another-app-id';
-    var token = cred.generateJwt(altAppId);
-    
-    expect(stub.generate).to.be.calledWith(cred.privateKey, altAppId);
-  });
-  
+describe('Credentials Object', function() {
+
+    it('should be possible to construct a Credential object', function() {
+        var cred = Credentials.parse('KEY', 'SECRET');
+
+        expect(cred).to.be.an.instanceof(Credentials);
+    });
+
+    it('should parse object literal into a Credential object', function() {
+        var key = 'KEY';
+        var secret = 'SECRET';
+        var appId = 'app-id';
+        var privateKey = __dirname + '/private-test.key';
+        var obj = {
+            apiKey: key,
+            apiSecret: secret,
+            applicationId: appId,
+            privateKey: privateKey
+        };
+        var parsed = Credentials.parse(obj);
+
+        expect(parsed).to.be.an.instanceof(Credentials);
+        expect(parsed.apiKey).to.be.equal(key);
+        expect(parsed.apiSecret).to.be.equal(secret);
+        expect(parsed.applicationId).to.be.equal(appId);
+        expect(parsed.privateKey).to.be.ok;
+    });
+
+    it('should throw an error when a privateKey is provided and the file does not exist', function() {
+        var create = function() {
+            new Credentials('KEY', 'SECRET', './no-key-here.key');
+        };
+        expect(create).to.throw(Error);
+    });
+
+
+    it('should read a private key into a Buffer accessible via Credentials.privateKey', function() {
+        var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key');
+        expect(cred.privateKey).to.be.an.instanceof(Buffer);
+    });
+
+    it('should allow an applicationId to be provided upon construction', function() {
+        var appId = 'some_app_id';
+        var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key', appId);
+        expect(cred.applicationId).to.equal(appId);
+    });
+
+    it('should allow a JWT to be generated using supplied application ID', function() {
+        var stub = sinon.createStubInstance(JwtGenerator);
+
+        var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key', 'app-id');
+        cred._setJwtGenerator(stub);
+
+        cred.generateJwt();
+
+        expect(stub.generate).to.be.calledWith(cred.privateKey, cred.applicationId);
+    });
+
+    it('should allow a JWT to be generated using an alternative application ID', function() {
+        var stub = sinon.createStubInstance(JwtGenerator);
+
+        var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key', 'app-id');
+        cred._setJwtGenerator(stub);
+
+        var altAppId = 'another-app-id';
+        cred.generateJwt(altAppId);
+
+        expect(stub.generate).to.be.calledWith(cred.privateKey, altAppId);
+    });
+
 });

--- a/test/DtmfResource-test.js
+++ b/test/DtmfResource-test.js
@@ -1,6 +1,8 @@
-import chai, { expect } from 'chai';
-import sinon            from 'sinon';
-import sinonChai        from 'sinon-chai';
+import chai, {
+    expect
+} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
@@ -11,38 +13,40 @@ import HttpClient from '../lib/HttpClient';
 import Credentials from '../lib/Credentials';
 
 var creds = Credentials.parse({
-  applicationId: 'some-id',
-  privateKey: __dirname + '/private-test.key'
+    applicationId: 'some-id',
+    privateKey: __dirname + '/private-test.key'
 });
 var emptyCallback = () => {};
 
 describe('DtmfResource', () => {
-  
-  var httpClientStub = null;
-  var dtmf = null;
-  
-  beforeEach(() => {
-    httpClientStub = sinon.createStubInstance(HttpClient);
-    var options = {
-      httpClient: httpClientStub
-    };
-    dtmf = new DtmfResource(creds, options);
-  })
-  
-  it('should be able to send DTMF to a call', () => {
-    const callId = '2342342-lkjhlkjh-32423';
-    var params = {digits: [1,2,3,4]};
-    dtmf.send(callId, params, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
-      path: DtmfResource.PATH.replace('{call_uuid}', callId),
-      method: 'PUT'
+
+    var httpClientStub = null;
+    var dtmf = null;
+
+    beforeEach(() => {
+        httpClientStub = sinon.createStubInstance(HttpClient);
+        var options = {
+            httpClient: httpClientStub
+        };
+        dtmf = new DtmfResource(creds, options);
     });
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
+
+    it('should be able to send DTMF to a call', () => {
+        const callId = '2342342-lkjhlkjh-32423';
+        var params = {
+            digits: [1, 2, 3, 4]
+        };
+        dtmf.send(callId, params, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
+            path: DtmfResource.PATH.replace('{call_uuid}', callId),
+            method: 'PUT'
+        });
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
 });

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -5,156 +5,215 @@ import HttpClient from '../lib/HttpClient';
 import NullLogger from '../lib/NullLogger';
 
 var logger = new NullLogger();
-var fakeHttp = {request: function() {}};
+var fakeHttp = {
+    request: function() {}
+};
 var fakeRequest = {
-  end: function(){},
-  on: function(){}
+    end: function() {},
+    on: function() {}
 };
 
 var defaultHeaders = {
-  "Content-Type": "application/x-www-form-urlencoded",
-  "Accept": "application/json"
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Accept': 'application/json'
 };
 
-describe('HttpClient Object', function () {
-  
-  afterEach(function() {
-    fakeHttp.request.restore();
-  });
-  
-  it('should support requests over https', function() {
-    var mock = sinon.mock(fakeHttp);
-    mock.expects('request')
-      .once()
-      .withArgs({
-        headers: defaultHeaders,
-        host: "api.nexmo.com",
-        method: "GET",
-        path: "/api",
-        port: 443
-      })
-      .returns(fakeRequest);
-    
-    var client = new HttpClient({https:fakeHttp, port:443, logger: logger});
-    
-    client.request({host:'api.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
-  });
-  
-  it('should support requests over http', function() {
-    var mock = sinon.mock(fakeHttp);
-    mock.expects('request')
-      .once()
-      .withArgs({
-        headers: defaultHeaders,
-        host: "api.nexmo.com",
-        method: "GET",
-        path: "/api",
-        port: 80
-      })
-      .returns(fakeRequest);
-    
-    var client = new HttpClient({http:fakeHttp, port:80, logger: logger});
-    
-    client.request({host:'api.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
-  });
-  
-  it('should be possible to set the host', function() {
-    var mock = sinon.mock(fakeHttp);
-    mock.expects('request')
-      .once()
-      .withArgs({
-        headers: defaultHeaders,
-        host: "rest.nexmo.com",
-        method: "GET",
-        path: "/api",
-        port: 80
-      })
-      .returns(fakeRequest);
-    
-    var client = new HttpClient({http:fakeHttp, port:80, logger: logger});
-    
-    client.request({host:'rest.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
-  });
-  
-  it('should be possible to set the path', function() {
-    var mock = sinon.mock(fakeHttp);
-    mock.expects('request')
-      .once()
-      .withArgs({
-        headers: defaultHeaders,
-        host: "api.nexmo.com",
-        method: "GET",
-        path: "/some_path",
-        port: 80
-      })
-      .returns(fakeRequest);
-    
-    var client = new HttpClient({http:fakeHttp, port:80, logger: logger});
-    
-    client.request({host:'api.nexmo.com', path: '/some_path'}, 'GET', {some: 'data'});
-  });
-  
-  it('should be possible to set the method', function() {
-    var mock = sinon.mock(fakeHttp);
-    mock.expects('request')
-      .once()
-      .withArgs({
-        headers: defaultHeaders,
-        host: "api.nexmo.com",
-        method: "POST",
-        path: "/api",
-        port: 443
-      })
-      .returns(fakeRequest);
-    
-    var client = new HttpClient({https:fakeHttp, logger: logger});
-    
-    client.request({host:'api.nexmo.com', path: '/api'}, 'POST', {some: 'data'});
-  });
-  
-  it('should log requests', function() {
-    var mock = sinon.mock(fakeHttp);
-    mock.expects('request').returns(fakeRequest);
-    
-    var logged = false;
-    var testLogger = {
-      info: function() {
-        logged = true;
-      }
-    };
-    var client = new HttpClient({https:fakeHttp, logger: testLogger});
-    
-    client.request({host:'api.nexmo.com', path: '/api'}, 'GET', {some: 'data'});
-    
-    expect(logged).to.be(true);
-  });
-  
-  it('should allow User-Agent header to be set via options', function() {
-    var expectedUserAgent = 'nexmo-node/1.0.0/v4.4.7';
-    
-    var mock = sinon.mock(fakeHttp);
-    mock.expects('request')
-      .once()
-      .withArgs({
-        headers:{
-          "Content-Type": "application/x-www-form-urlencoded",
-          "Accept": "application/json",
-          "User-Agent": expectedUserAgent
-        },
-        host: "api.nexmo.com",
-        method: "POST",
-        path: "/api",
-        port: 443
-      })
-      .returns(fakeRequest);
-    
-    var client = new HttpClient({
-      https:fakeHttp,
-      logger: logger,
-      userAgent: expectedUserAgent
+describe('HttpClient Object', function() {
+
+    afterEach(function() {
+        fakeHttp.request.restore();
     });
-    
-    client.request({host:'api.nexmo.com', path: '/api'}, 'POST', {some: 'data'});
-  });
+
+    it('should support requests over https', function() {
+        var mock = sinon.mock(fakeHttp);
+        mock.expects('request')
+            .once()
+            .withArgs({
+                headers: defaultHeaders,
+                host: 'api.nexmo.com',
+                method: 'GET',
+                path: '/api',
+                port: 443
+            })
+            .returns(fakeRequest);
+
+        var client = new HttpClient({
+            https: fakeHttp,
+            port: 443,
+            logger: logger
+        });
+
+        client.request({
+            host: 'api.nexmo.com',
+            path: '/api'
+        }, 'GET', {
+            some: 'data'
+        });
+    });
+
+    it('should support requests over http', function() {
+        var mock = sinon.mock(fakeHttp);
+        mock.expects('request')
+            .once()
+            .withArgs({
+                headers: defaultHeaders,
+                host: 'api.nexmo.com',
+                method: 'GET',
+                path: '/api',
+                port: 80
+            })
+            .returns(fakeRequest);
+
+        var client = new HttpClient({
+            http: fakeHttp,
+            port: 80,
+            logger: logger
+        });
+
+        client.request({
+            host: 'api.nexmo.com',
+            path: '/api'
+        }, 'GET', {
+            some: 'data'
+        });
+    });
+
+    it('should be possible to set the host', function() {
+        var mock = sinon.mock(fakeHttp);
+        mock.expects('request')
+            .once()
+            .withArgs({
+                headers: defaultHeaders,
+                host: 'rest.nexmo.com',
+                method: 'GET',
+                path: '/api',
+                port: 80
+            })
+            .returns(fakeRequest);
+
+        var client = new HttpClient({
+            http: fakeHttp,
+            port: 80,
+            logger: logger
+        });
+
+        client.request({
+            host: 'rest.nexmo.com',
+            path: '/api'
+        }, 'GET', {
+            some: 'data'
+        });
+    });
+
+    it('should be possible to set the path', function() {
+        var mock = sinon.mock(fakeHttp);
+        mock.expects('request')
+            .once()
+            .withArgs({
+                headers: defaultHeaders,
+                host: 'api.nexmo.com',
+                method: 'GET',
+                path: '/some_path',
+                port: 80
+            })
+            .returns(fakeRequest);
+
+        var client = new HttpClient({
+            http: fakeHttp,
+            port: 80,
+            logger: logger
+        });
+
+        client.request({
+            host: 'api.nexmo.com',
+            path: '/some_path'
+        }, 'GET', {
+            some: 'data'
+        });
+    });
+
+    it('should be possible to set the method', function() {
+        var mock = sinon.mock(fakeHttp);
+        mock.expects('request')
+            .once()
+            .withArgs({
+                headers: defaultHeaders,
+                host: 'api.nexmo.com',
+                method: 'POST',
+                path: '/api',
+                port: 443
+            })
+            .returns(fakeRequest);
+
+        var client = new HttpClient({
+            https: fakeHttp,
+            logger: logger
+        });
+
+        client.request({
+            host: 'api.nexmo.com',
+            path: '/api'
+        }, 'POST', {
+            some: 'data'
+        });
+    });
+
+    it('should log requests', function() {
+        var mock = sinon.mock(fakeHttp);
+        mock.expects('request').returns(fakeRequest);
+
+        var logged = false;
+        var testLogger = {
+            info: function() {
+                logged = true;
+            }
+        };
+        var client = new HttpClient({
+            https: fakeHttp,
+            logger: testLogger
+        });
+
+        client.request({
+            host: 'api.nexmo.com',
+            path: '/api'
+        }, 'GET', {
+            some: 'data'
+        });
+
+        expect(logged).to.be(true);
+    });
+
+    it('should allow User-Agent header to be set via options', function() {
+        var expectedUserAgent = 'nexmo-node/1.0.0/v4.4.7';
+
+        var mock = sinon.mock(fakeHttp);
+        mock.expects('request')
+            .once()
+            .withArgs({
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Accept': 'application/json',
+                    'User-Agent': expectedUserAgent
+                },
+                host: 'api.nexmo.com',
+                method: 'POST',
+                path: '/api',
+                port: 443
+            })
+            .returns(fakeRequest);
+
+        var client = new HttpClient({
+            https: fakeHttp,
+            logger: logger,
+            userAgent: expectedUserAgent
+        });
+
+        client.request({
+            host: 'api.nexmo.com',
+            path: '/api'
+        }, 'POST', {
+            some: 'data'
+        });
+    });
 
 });

--- a/test/JwtGenerator-test.js
+++ b/test/JwtGenerator-test.js
@@ -2,27 +2,27 @@ import JwtGenerator from '../src/JwtGenerator';
 import fs from 'fs';
 import expect from 'expect.js';
 
-describe('JwtGenerator Object', function () {
-	
-	describe('.generate', function () {
-		
-		it('should throw an exception if the cert is not a Buffer', function() {
-			var generator = new JwtGenerator();
-			var generate = function() {
-				generator.generate('blah blah', 'application_id');
-			};
-			expect(generate).to.throwError();
-		});
-		
-		it('should generate a JWT', function() {			
-			var testPrivateKey = fs.readFileSync(__dirname + '/private-test.key');
-			
-			var generator = new JwtGenerator();
-			var token = generator.generate(testPrivateKey, 'app-id', new Date(2016, 9, 5).getTime(), 'jwt-id')
-			
-			expect(token).to.be.a('string');
-		});
-		
-	})
-	
+describe('JwtGenerator Object', function() {
+
+    describe('.generate', function() {
+
+        it('should throw an exception if the cert is not a Buffer', function() {
+            var generator = new JwtGenerator();
+            var generate = function() {
+                generator.generate('blah blah', 'application_id');
+            };
+            expect(generate).to.throwError();
+        });
+
+        it('should generate a JWT', function() {
+            var testPrivateKey = fs.readFileSync(__dirname + '/private-test.key');
+
+            var generator = new JwtGenerator();
+            var token = generator.generate(testPrivateKey, 'app-id', new Date(2016, 9, 5).getTime(), 'jwt-id');
+
+            expect(token).to.be.a('string');
+        });
+
+    });
+
 });

--- a/test/Message-test.js
+++ b/test/Message-test.js
@@ -3,22 +3,22 @@ import Message from '../lib/Message';
 import NexmoStub from './NexmoStub';
 
 var smsAPIs = {
-  'sendBinaryMessage': 'sendBinaryMessage',
-  'sendWapPushMessage': 'sendWapPushMessage',
-  'sendTextMessage': 'sendSms',
-  'shortcodeAlert': 'shortcodeAlert',
-  'shortcode2FA': 'shortcode2FA',
-  'shortcodeMarketing': 'shortcodeMarketing'
+    'sendBinaryMessage': 'sendBinaryMessage',
+    'sendWapPushMessage': 'sendWapPushMessage',
+    'sendTextMessage': 'sendSms',
+    'shortcodeAlert': 'shortcodeAlert',
+    'shortcode2FA': 'shortcode2FA',
+    'shortcodeMarketing': 'shortcodeMarketing'
 };
 
-describe('Message Object', function () {
-  
-  it('should implement all v1 APIs', function() {
-    NexmoStub.checkAllFunctionsAreDefined(smsAPIs, Message);
-  });
-  
-  it('should proxy the function call to the underlying `nexmo` object', function() {
-    NexmoStub.checkAllFunctionsAreCalled(smsAPIs, Message);
-  });
-  
+describe('Message Object', function() {
+
+    it('should implement all v1 APIs', function() {
+        NexmoStub.checkAllFunctionsAreDefined(smsAPIs, Message);
+    });
+
+    it('should proxy the function call to the underlying `nexmo` object', function() {
+        NexmoStub.checkAllFunctionsAreCalled(smsAPIs, Message);
+    });
+
 });

--- a/test/Nexmo-test.js
+++ b/test/Nexmo-test.js
@@ -1,114 +1,171 @@
-import chai, { expect } from 'chai';
-import sinon            from 'sinon';
-import sinonChai        from 'sinon-chai';
+import chai, {
+    expect
+} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
 import Nexmo from '../lib/Nexmo';
 import CallsResource from '../lib/CallsResource';
 
-describe('Nexmo Object instance', function () {
+describe('Nexmo Object instance', function() {
 
-  it('should expose a credentials object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.credentials).to.be.a('object');
-  });
-  
-  it('should expose a message object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.message).to.be.a('object');
-  });
-  
-  it('should expose a voice object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.voice).to.be.a('object');
-  });
-  
-  it('should expose a number object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.number).to.be.a('object');
-  });
-  
-  it('should expose a verify object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.verify).to.be.a('object');
-  });
-  
-  it('should expose a numberInsight object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.numberInsight).to.be.a('object');
-  });
-    
-  it('should expose a app object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.app).to.be.a('object');
-  });
-  
-  it('should expose a applications object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.applications).to.be.a('object');
-  });
-  
-  it('should alias apps to applications object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.applications).to.equal(nexmo.app);
-  });
-  
-  it('should expose a account object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.account).to.be.a('object');
-  });
-  
-  it('should expose a calls object', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect(nexmo.calls).to.be.an.instanceOf(CallsResource);
-  });
-  
-  it('should allow options to be passed', function () {
-    var initializedSpy = sinon.spy();
-    var options = {
-      nexmoOverride: {
-        initialize: initializedSpy
-      },
-      appendToUserAgent: 'EXT',
-      debug: true
-    };
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'}, options);
-    expect( initializedSpy.calledWith('test', 'test', options) ).to.be.true;
-  });
+    it('should expose a credentials object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.credentials).to.be.a('object');
+    });
 
-  it('should have debug turned off by default', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect( nexmo.options.debug ).to.be.false;
-  });
-  
-  it('should allow a custom logger to be set', function () {
-    var logger = {
-      info: function(){},
-      error: function() {},
-      warn: function() {}
-    };
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'}, {logger: logger});
-    console.log(nexmo.options.logger);
-    expect( nexmo.options.logger ).to.equal(logger);
-  });
+    it('should expose a message object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.message).to.be.a('object');
+    });
 
-  it('should allow a debug option to be set', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'}, { debug: true });
-    expect( nexmo.options.debug ).to.be.true;
-  });
-  
-  it('should have a default user agent in the form LIBRARY-NAME/LIBRARY-VERSION/LANGUAGE-VERSION', function () {
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'});
-    expect( nexmo.options.userAgent ).to.match(/.*\/.*\/.*$/);
-  });
+    it('should expose a voice object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.voice).to.be.a('object');
+    });
 
-  it('should append to the user agent when a appendToUserAgent option is passed', function () {
-    var options = {
-      appendToUserAgent: 'EXT'
-    };
-    var nexmo = new Nexmo({apiKey:'test', apiSecret:'test'}, options);
-    expect( nexmo.options.userAgent ).to.match(/\/EXT$/);
-  });
-  
+    it('should expose a number object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.number).to.be.a('object');
+    });
+
+    it('should expose a verify object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.verify).to.be.a('object');
+    });
+
+    it('should expose a numberInsight object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.numberInsight).to.be.a('object');
+    });
+
+    it('should expose a app object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.app).to.be.a('object');
+    });
+
+    it('should expose a applications object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.applications).to.be.a('object');
+    });
+
+    it('should alias apps to applications object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.applications).to.equal(nexmo.app);
+    });
+
+    it('should expose a account object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.account).to.be.a('object');
+    });
+
+    it('should expose a calls object', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.calls).to.be.an.instanceOf(CallsResource);
+    });
+
+    it('should allow options to be passed', function() {
+        var initializedSpy = sinon.spy();
+        var options = {
+            nexmoOverride: {
+                initialize: initializedSpy
+            },
+            appendToUserAgent: 'EXT',
+            debug: true
+        };
+        new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        }, options);
+        expect(initializedSpy.calledWith('test', 'test', options)).to.be.true;
+    });
+
+    it('should have debug turned off by default', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.options.debug).to.be.false;
+    });
+
+    it('should allow a custom logger to be set', function() {
+        var logger = {
+            info: function() {},
+            error: function() {},
+            warn: function() {}
+        };
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        }, {
+            logger: logger
+        });
+        // console.log(nexmo.options.logger);
+        expect(nexmo.options.logger).to.equal(logger);
+    });
+
+    it('should allow a debug option to be set', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        }, {
+            debug: true
+        });
+        expect(nexmo.options.debug).to.be.true;
+    });
+
+    it('should have a default user agent in the form LIBRARY-NAME/LIBRARY-VERSION/LANGUAGE-VERSION', function() {
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        });
+        expect(nexmo.options.userAgent).to.match(/.*\/.*\/.*$/);
+    });
+
+    it('should append to the user agent when a appendToUserAgent option is passed', function() {
+        var options = {
+            appendToUserAgent: 'EXT'
+        };
+        var nexmo = new Nexmo({
+            apiKey: 'test',
+            apiSecret: 'test'
+        }, options);
+        expect(nexmo.options.userAgent).to.match(/\/EXT$/);
+    });
+
 });

--- a/test/NexmoStub.js
+++ b/test/NexmoStub.js
@@ -1,66 +1,70 @@
 import expect from 'expect.js';
 
 class NexmoStub {
-  
-  static create(functions) {
-        
-    var stub = {
-      initialize: function() {},
-      hasBeenCalled: function(name) {
-        return this[name + '_called'] === true;
-      }
-    };
-    functions.forEach(function(name) {
-      stub[name + '_called'] = false;
-      stub[name] = function() {
-        this[name + '_called'] = true;
-      };
-    });
-    
-    return stub;
-    
-  }
-  
-  /**
-   * @param {Object} mappings - a mapping from legacy global function to
-   *                  new non-global name.
-   */
-  static checkAllFunctionsAreDefined(mappings, obj) {
-    Object.keys(mappings).forEach(function(originalName) {
-      var newName = mappings[originalName].split('|')[0];
-      expect(obj.prototype[newName]).to.be.a('function');
-    });
-  }
-  
-  /**
-   * @param {Object} mappings - a mapping from legacy global function to
-   *                  new non-global name.
-   */
-  static checkAllFunctionsAreCalled(mappings, objDef) {
-    Object.keys(mappings).forEach(function(originalName) {
-      var nameAndParams = mappings[originalName].split('|');
-      var newName = nameAndParams[0];
-      var params = nameAndParams[1]?nameAndParams[1].split(','):[];
-      params.forEach(function(paramValue, index) {
-        try {
-          params[index] = JSON.parse(paramValue)
-        }
-        catch (e) {
-          // couldn't be parsed, which is fine.
-          // console.log('could not parse', paramValue);
-        }
-      });
-      
-      var stub = NexmoStub.create(Object.keys(mappings));
-      var obj = new objDef({apiKey:'test', apiSecret:'test'}, {nexmoOverride: stub});
-      
-      console.log('calling', newName, '(' + params + ')', 'expecting', originalName);
-      obj[newName].apply(obj, params);
-      
-      expect( stub.hasBeenCalled(originalName) ).to.be(true);
-    });
-  }
-    
+
+    static create(functions) {
+
+        var stub = {
+            initialize: function() {},
+            hasBeenCalled: function(name) {
+                return this[name + '_called'] === true;
+            }
+        };
+        functions.forEach(function(name) {
+            stub[name + '_called'] = false;
+            stub[name] = function() {
+                this[name + '_called'] = true;
+            };
+        });
+
+        return stub;
+
+    }
+
+    /**
+     * @param {Object} mappings - a mapping from legacy global function to
+     *                  new non-global name.
+     */
+    static checkAllFunctionsAreDefined(mappings, obj) {
+        Object.keys(mappings).forEach(function(originalName) {
+            var newName = mappings[originalName].split('|')[0];
+            expect(obj.prototype[newName]).to.be.a('function');
+        });
+    }
+
+    /**
+     * @param {Object} mappings - a mapping from legacy global function to
+     *                  new non-global name.
+     */
+    static checkAllFunctionsAreCalled(mappings, objDef) {
+        Object.keys(mappings).forEach(function(originalName) {
+            var nameAndParams = mappings[originalName].split('|');
+            var newName = nameAndParams[0];
+            var params = nameAndParams[1] ? nameAndParams[1].split(',') : [];
+            params.forEach(function(paramValue, index) {
+                try {
+                    params[index] = JSON.parse(paramValue);
+                } catch (e) {
+                    // couldn't be parsed, which is fine.
+                    // console.log('could not parse', paramValue);
+                }
+            });
+
+            var stub = NexmoStub.create(Object.keys(mappings));
+            var obj = new objDef({
+                apiKey: 'test',
+                apiSecret: 'test'
+            }, {
+                nexmoOverride: stub
+            });
+
+            // console.log('calling', newName, '(' + params + ')', 'expecting', originalName);
+            obj[newName].apply(obj, params);
+
+            expect(stub.hasBeenCalled(originalName)).to.be(true);
+        });
+    }
+
 }
 
 export default NexmoStub;

--- a/test/Number-test.js
+++ b/test/Number-test.js
@@ -3,23 +3,23 @@ import Number from '../lib/Number';
 import NexmoStub from './NexmoStub';
 
 var numberAPIs = {
-  'getPricing': 'getPricing',
-  'getPhonePricing': 'getPhonePricing',
-  'getNumbers': 'get',
-  'searchNumbers': 'search',
-  'buyNumber': 'buy',
-  'cancelNumber': 'cancel',
-  'updateNumber': 'update'
+    'getPricing': 'getPricing',
+    'getPhonePricing': 'getPhonePricing',
+    'getNumbers': 'get',
+    'searchNumbers': 'search',
+    'buyNumber': 'buy',
+    'cancelNumber': 'cancel',
+    'updateNumber': 'update'
 };
 
-describe('Number Object', function () {
-  
-  it('should implement all v1 APIs', function() {
-    NexmoStub.checkAllFunctionsAreDefined(numberAPIs, Number);
-  });
-  
-  it('should proxy the function call to the underlying `nexmo` object', function() {
-    NexmoStub.checkAllFunctionsAreCalled(numberAPIs, Number);
-  });
-  
+describe('Number Object', function() {
+
+    it('should implement all v1 APIs', function() {
+        NexmoStub.checkAllFunctionsAreDefined(numberAPIs, Number);
+    });
+
+    it('should proxy the function call to the underlying `nexmo` object', function() {
+        NexmoStub.checkAllFunctionsAreCalled(numberAPIs, Number);
+    });
+
 });

--- a/test/NumberInsight-test.js
+++ b/test/NumberInsight-test.js
@@ -3,20 +3,20 @@ import NumberInsight from '../lib/NumberInsight';
 import NexmoStub from './NexmoStub';
 
 var numberInsightAPIs = {
-  'numberInsightAdvancedAsync': 'get|{"level":"advancedAsync"}',
-  'numberInsightAdvanced': 'get|{"level":"advanced"}',
-  'numberInsightStandard': 'get|{"level":"standard"}',
-  'numberInsightBasic': 'get|{"level":"basic"}'
+    'numberInsightAdvancedAsync': 'get|{"level":"advancedAsync"}',
+    'numberInsightAdvanced': 'get|{"level":"advanced"}',
+    'numberInsightStandard': 'get|{"level":"standard"}',
+    'numberInsightBasic': 'get|{"level":"basic"}'
 };
 
-describe('NumberInsight Object', function () {
+describe('NumberInsight Object', function() {
 
-  it('should implement all v1 APIs', function() {
-    NexmoStub.checkAllFunctionsAreDefined(numberInsightAPIs, NumberInsight);
-  });
+    it('should implement all v1 APIs', function() {
+        NexmoStub.checkAllFunctionsAreDefined(numberInsightAPIs, NumberInsight);
+    });
 
-  it('should proxy the function call to the underlying `nexmo` object', function() {
-    NexmoStub.checkAllFunctionsAreCalled(numberInsightAPIs, NumberInsight);
-  });
+    it('should proxy the function call to the underlying `nexmo` object', function() {
+        NexmoStub.checkAllFunctionsAreCalled(numberInsightAPIs, NumberInsight);
+    });
 
 });

--- a/test/ResourceTestHelper.js
+++ b/test/ResourceTestHelper.js
@@ -1,42 +1,42 @@
 class ResourceTestHelper {
-  
-  static getRequestArgs(params, overrides = {}) {
-    var callsArgs = {
-      host: overrides.host       || 'api.nexmo.com',
-      path: overrides.path       || '/v1/calls',
-      method: overrides.method   || 'POST',
-      body: overrides.hasOwnProperty('body')? overrides.body : JSON.stringify(params),
-      headers: overrides.headers || {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer '
-      }
-    };
-    
-    // Removed undefined properties
-    Object.keys(callsArgs).forEach(function(key) {
-      if(callsArgs[key] === undefined) {
-        delete callsArgs[key];
-      }
-    });
-    
-    return callsArgs;
-  }
 
-  static requestArgsMatch(params, requestOverrides) {
-    return function(actual) {
-      var expected = ResourceTestHelper.getRequestArgs(params, requestOverrides);
-      
-      var match = (
-        expected.host === actual.host &&
-        expected.path === actual.path &&
-        expected.method === actual.method &&
-        expected.body === actual.body &&
-        expected.headers['Content-Type'] === actual.headers['Content-Type'] &&
-        actual.headers['Authorization'].indexOf(expected.headers['Authorization']) == 0
-      );
-      return match;
+    static getRequestArgs(params, overrides = {}) {
+        var callsArgs = {
+            host: overrides.host || 'api.nexmo.com',
+            path: overrides.path || '/v1/calls',
+            method: overrides.method || 'POST',
+            body: overrides.hasOwnProperty('body') ? overrides.body : JSON.stringify(params),
+            headers: overrides.headers || {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer '
+            }
+        };
+
+        // Removed undefined properties
+        Object.keys(callsArgs).forEach(function(key) {
+            if (callsArgs[key] === undefined) {
+                delete callsArgs[key];
+            }
+        });
+
+        return callsArgs;
     }
-  }
+
+    static requestArgsMatch(params, requestOverrides) {
+        return function(actual) {
+            var expected = ResourceTestHelper.getRequestArgs(params, requestOverrides);
+
+            var match = (
+                expected.host === actual.host &&
+                expected.path === actual.path &&
+                expected.method === actual.method &&
+                expected.body === actual.body &&
+                expected.headers['Content-Type'] === actual.headers['Content-Type'] &&
+                actual.headers['Authorization'].indexOf(expected.headers['Authorization']) == 0
+            );
+            return match;
+        };
+    }
 }
 
 export default ResourceTestHelper;

--- a/test/StreamResource-test.js
+++ b/test/StreamResource-test.js
@@ -1,67 +1,69 @@
-import chai, { expect } from 'chai';
-import sinon            from 'sinon';
-import sinonChai        from 'sinon-chai';
+import chai, {
+    expect
+} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
 import ResourceTestHelper from './ResourceTestHelper';
-
-import querystring from 'querystring';
 
 import StreamResource from '../lib/StreamResource';
 import HttpClient from '../lib/HttpClient';
 import Credentials from '../lib/Credentials';
 
 var creds = Credentials.parse({
-  applicationId: 'some-id',
-  privateKey: __dirname + '/private-test.key'
+    applicationId: 'some-id',
+    privateKey: __dirname + '/private-test.key'
 });
 var emptyCallback = () => {};
 
 describe('StreamResource', () => {
-  
-  var httpClientStub = null;
-  var stream = null;
-  
-  beforeEach(() => {
-    httpClientStub = sinon.createStubInstance(HttpClient);
-    var options = {
-      httpClient: httpClientStub
-    };
-    stream = new StreamResource(creds, options);
-  })
-  
-  it('should allow a stream to be started', () => {
-    const callId = '2342342-lkjhlkjh-32423';
-    var params = {stream_url: 'https://example.com/test.mp3'};
-    stream.start(callId, params, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
-      path: StreamResource.PATH.replace('{call_uuid}', callId),
-      method: 'PUT'
+
+    var httpClientStub = null;
+    var stream = null;
+
+    beforeEach(() => {
+        httpClientStub = sinon.createStubInstance(HttpClient);
+        var options = {
+            httpClient: httpClientStub
+        };
+        stream = new StreamResource(creds, options);
     });
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
-  it('should be possible to stop a stream', () => {
-    const callId = '2342342-lkjhlkjh-32423';
-    stream.stop(callId, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
-      method: 'DELETE',
-      body: undefined,
-      path: StreamResource.PATH.replace('{call_uuid}', callId),
+
+    it('should allow a stream to be started', () => {
+        const callId = '2342342-lkjhlkjh-32423';
+        var params = {
+            stream_url: 'https://example.com/test.mp3' // eslint-disable-line camelcase
+        }; // eslint-disable-line camelcase
+        stream.start(callId, params, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
+            path: StreamResource.PATH.replace('{call_uuid}', callId),
+            method: 'PUT'
+        });
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
     });
-    
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
+
+    it('should be possible to stop a stream', () => {
+        const callId = '2342342-lkjhlkjh-32423';
+        stream.stop(callId, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
+            method: 'DELETE',
+            body: undefined,
+            path: StreamResource.PATH.replace('{call_uuid}', callId),
+        });
+
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
 });

--- a/test/StreamResource-test.js
+++ b/test/StreamResource-test.js
@@ -56,7 +56,7 @@ describe('StreamResource', () => {
         var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
             method: 'DELETE',
             body: undefined,
-            path: StreamResource.PATH.replace('{call_uuid}', callId),
+            path: StreamResource.PATH.replace('{call_uuid}', callId)
         });
 
         expect(httpClientStub.request)

--- a/test/TalkResource-test.js
+++ b/test/TalkResource-test.js
@@ -56,7 +56,7 @@ describe('TalkResource', () => {
         var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
             method: 'DELETE',
             body: undefined,
-            path: TalkResource.PATH.replace('{call_uuid}', callId),
+            path: TalkResource.PATH.replace('{call_uuid}', callId)
         });
 
         expect(httpClientStub.request)

--- a/test/TalkResource-test.js
+++ b/test/TalkResource-test.js
@@ -1,6 +1,8 @@
-import chai, { expect } from 'chai';
-import sinon            from 'sinon';
-import sinonChai        from 'sinon-chai';
+import chai, {
+    expect
+} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
@@ -11,55 +13,57 @@ import HttpClient from '../lib/HttpClient';
 import Credentials from '../lib/Credentials';
 
 var creds = Credentials.parse({
-  applicationId: 'some-id',
-  privateKey: __dirname + '/private-test.key'
+    applicationId: 'some-id',
+    privateKey: __dirname + '/private-test.key'
 });
 var emptyCallback = () => {};
 
 describe('TalkResource', () => {
-  
-  var httpClientStub = null;
-  var talk = null;
-  
-  beforeEach(() => {
-    httpClientStub = sinon.createStubInstance(HttpClient);
-    var options = {
-      httpClient: httpClientStub
-    };
-    talk = new TalkResource(creds, options);
-  })
-  
-  it('should be able to start a talk', () => {
-    const callId = '2342342-lkjhlkjh-32423';
-    var params = {text: 'Hello!'};
-    talk.start(callId, params, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
-      path: TalkResource.PATH.replace('{call_uuid}', callId),
-      method: 'PUT'
+
+    var httpClientStub = null;
+    var talk = null;
+
+    beforeEach(() => {
+        httpClientStub = sinon.createStubInstance(HttpClient);
+        var options = {
+            httpClient: httpClientStub
+        };
+        talk = new TalkResource(creds, options);
     });
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
-  it('should be possible to stop an ongoing talk', () => {
-    const callId = '2342342-lkjhlkjh-32423';
-    talk.stop(callId, emptyCallback);
-    
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
-      method: 'DELETE',
-      body: undefined,
-      path: TalkResource.PATH.replace('{call_uuid}', callId),
+
+    it('should be able to start a talk', () => {
+        const callId = '2342342-lkjhlkjh-32423';
+        var params = {
+            text: 'Hello!'
+        };
+        talk.start(callId, params, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
+            path: TalkResource.PATH.replace('{call_uuid}', callId),
+            method: 'PUT'
+        });
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
     });
-    
-    expect(httpClientStub.request)
-      .to.have.been.calledWith(
-        sinon.match(expectedRequestArgs),
-        emptyCallback
-      );
-  });
-  
+
+    it('should be possible to stop an ongoing talk', () => {
+        const callId = '2342342-lkjhlkjh-32423';
+        talk.stop(callId, emptyCallback);
+
+        var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(null, {
+            method: 'DELETE',
+            body: undefined,
+            path: TalkResource.PATH.replace('{call_uuid}', callId),
+        });
+
+        expect(httpClientStub.request)
+            .to.have.been.calledWith(
+                sinon.match(expectedRequestArgs),
+                emptyCallback
+            );
+    });
+
 });

--- a/test/Verify-test.js
+++ b/test/Verify-test.js
@@ -3,20 +3,20 @@ import Verify from '../lib/Verify';
 import NexmoStub from './NexmoStub';
 
 var verifyAPIs = {
-  'verifyNumber': 'request',
-  'checkVerifyRequest': 'check',
-  'controlVerifyRequest': 'control',
-  'searchVerifyRequest': 'search'  
+    'verifyNumber': 'request',
+    'checkVerifyRequest': 'check',
+    'controlVerifyRequest': 'control',
+    'searchVerifyRequest': 'search'
 };
 
-describe('Verify Object', function () {
-  
-  it('should implement all v1 APIs', function() {
-    NexmoStub.checkAllFunctionsAreDefined(verifyAPIs, Verify);
-  });
-  
-  it('should proxy the function call to the underlying `nexmo` object', function() {
-    NexmoStub.checkAllFunctionsAreCalled(verifyAPIs, Verify);
-  });
-  
+describe('Verify Object', function() {
+
+    it('should implement all v1 APIs', function() {
+        NexmoStub.checkAllFunctionsAreDefined(verifyAPIs, Verify);
+    });
+
+    it('should proxy the function call to the underlying `nexmo` object', function() {
+        NexmoStub.checkAllFunctionsAreCalled(verifyAPIs, Verify);
+    });
+
 });

--- a/test/Voice-test.js
+++ b/test/Voice-test.js
@@ -3,20 +3,20 @@ import Voice from '../lib/Voice';
 import NexmoStub from './NexmoStub';
 
 var voiceAPIs = {
-  'sendTTSMessage': 'sendTTSMessage',
-  'sendTTSPromptWithCapture': 'sendTTSPromptWithCapture',
-  'sendTTSPromptWithConfirm': 'sendTTSPromptWithConfirm',
-  'call': 'call'  
+    'sendTTSMessage': 'sendTTSMessage',
+    'sendTTSPromptWithCapture': 'sendTTSPromptWithCapture',
+    'sendTTSPromptWithConfirm': 'sendTTSPromptWithConfirm',
+    'call': 'call'
 };
 
-describe('Voice Object', function () {
-  
-  it('should implement all v1 APIs', function() {
-    NexmoStub.checkAllFunctionsAreDefined(voiceAPIs, Voice);
-  });
+describe('Voice Object', function() {
 
-  it('should proxy the function call to the underlying `nexmo` object', function() {
-    NexmoStub.checkAllFunctionsAreCalled(voiceAPIs, Voice);
-  });
-  
+    it('should implement all v1 APIs', function() {
+        NexmoStub.checkAllFunctionsAreDefined(voiceAPIs, Voice);
+    });
+
+    it('should proxy the function call to the underlying `nexmo` object', function() {
+        NexmoStub.checkAllFunctionsAreCalled(voiceAPIs, Voice);
+    });
+
 });


### PR DESCRIPTION
- Use ESLint to lint all test files enforcing:
  - No trailing white space
  - Trailing semi colons
  - Camelcase variables and params
  - Unix linebreaks (no windows line breaks which will break things
  - Single quotes for regular string, backticks for interpolated strings
  - Warnings on console statements left in code
- All tests still pass
- Used Atom-Beautify gem package to fix indentation and restructure code to be more readable
- Added more node versions to our Travis build:
  - 0.11
  - 0.12
  - 4
  - 5
  - 6
