### PR TITLE
Make advanced and advancedSync backwards compatible

### DIFF
--- a/src/NumberInsight.js
+++ b/src/NumberInsight.js
@@ -71,10 +71,11 @@ class NumberInsight {
     // remove 'level' as it's a library-only parameter
     delete options.level;
 
-    if (level === 'advancedAsync') {
+    if (level === 'advanced' || level === 'advancedAsync') {
+      if (level === 'advanced') { console.warn('DEPRECATION WARNING: Number Insight Advanced with a level of "advanced" will be synchronous in v2.0+. Consider using the level "advancedAsync" to keep using the async option.') };
       this._nexmo.numberInsightAdvancedAsync.apply(this._nexmo, arguments);
     }
-    else if(level === 'advanced') {
+    else if(level === 'advancedSync') {
       this._nexmo.numberInsightAdvanced.apply(this._nexmo, arguments);
     }
     else if(level === 'standard') {

--- a/test/NumberInsight-test.js
+++ b/test/NumberInsight-test.js
@@ -3,8 +3,9 @@ import NumberInsight from '../lib/NumberInsight';
 import NexmoStub from './NexmoStub';
 
 var numberInsightAPIs = {
+  'numberInsightAdvancedAsync': 'get|{"level":"advanced"}',
   'numberInsightAdvancedAsync': 'get|{"level":"advancedAsync"}',
-  'numberInsightAdvanced': 'get|{"level":"advanced"}',
+  'numberInsightAdvanced': 'get|{"level":"advancedSync"}',
   'numberInsightStandard': 'get|{"level":"standard"}',
   'numberInsightBasic': 'get|{"level":"basic"}'
 };


### PR DESCRIPTION
Following our discussion in #66 I've renamed the levels and added a deprecation warning for users so we can change the `advanced` level in 2.0.

@tjlytle you agree this works?
