### PR TITLE
Add examples for talk resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,27 @@ nexmo.calls.stream.stop(callId);
 
 For more information see https://docs.nexmo.com/voice/voice-api/api-reference#stream_delete
 
+### Play synthesized text in a call
+
+```js
+nexmo.calls.talk.start(
+  callId,
+  {
+    text: 'No songs detected',
+    voiceName: 'Emma',
+    loop: 1
+  }
+);
+```
+
+For more information see https://docs.nexmo.com/voice/voice-api/api-reference#talk_put
+
+### Stop synthesized text in a call
+
+```js
+nexmo.calls.talk.stop(callId);
+```
+
 ### Send DTMF to a Call
 
 ```js
@@ -409,7 +430,7 @@ var nexmo = new Nexmo({
     applicationId: APP_ID,
     privateKey: PRIVATE_KEY_PATH,
   });
-  
+
 var jwt = nexmo.generateJwt();
 ```
 


### PR DESCRIPTION
There were no examples for using the `/v1/calls/{uuid}/talk` endpoint, something which I would have found very useful for getting a project of mine up and running. Done in the same format as similar existing examples.