### PR TITLE
Fix for #88 where method is undefined

### DIFF
--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -22,8 +22,8 @@ class HttpClient {
         callback = method;
         endpoint.method = endpoint.method || 'GET';
     }
-    else {
-      endpoint.method = method;
+    else if (typeof method !== 'undefined') {
+      	endpoint.method = method;
     }
     
     if (endpoint.method == 'POST' || endpoint.method == 'DELETE') {


### PR DESCRIPTION
When 'method' variable is undefined, endpoint.method is set to an undefined value, so the request fails. Fixed this by checking if it is undefined, therefore the value inside endpoint.method will remain the same.