### PR TITLE
Fix lint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
     'rules': {
         'indent': [
             'warn',
-            2
+            4
         ],
         'linebreak-style': [
             'error',

--- a/test/Nexmo-test.js
+++ b/test/Nexmo-test.js
@@ -217,11 +217,11 @@ describe('Nexmo Object instance', function() {
 
         var expectedJwt = Nexmo.generateJwt(
           privateKey,
-          {
-              'application_id': appId,
-            'iat': iat,
-              'jti': jti
-          }
+            {
+                'application_id': appId,
+                'iat': iat,
+                'jti': jti
+            }
         );
 
         var nexmo = new Nexmo({


### PR DESCRIPTION
Test linting was already in place but failing due to most of the code using 4 spaces and the linter expecting 2. By changing the linter to 4 and fixing 4 lines of code we now got rid of all warnings.

Closes #67 
