### PR TITLE
Fix/credential privateKey string check

### DIFF
--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -26,7 +26,7 @@ class Credentials {
     if(privateKey instanceof Buffer) {
       this.privateKey = privateKey;
     }
-    else if(privateKey instanceof String &&
+    else if(typeof privateKey === "string" &&
        privateKey.startsWith('-----BEGIN PRIVATE KEY-----')) {
       this.privateKey = new Buffer(privateKey);
     }

--- a/test/Credentials-test.js
+++ b/test/Credentials-test.js
@@ -57,6 +57,15 @@ describe('Credentials Object', function() {
     expect(cred.privateKey).to.be.an.instanceof(Buffer);
   });
 
+  it('should support passing privateKey as a String', function() {
+    var key =
+`-----BEGIN PRIVATE KEY-----
+blah blah blah
+-----END PRIVATE KEY-----`;
+    var cred = new Credentials('KEY', 'SECRET', key);
+    expect(cred.privateKey).to.be.an.instanceof(Buffer);
+  });
+
   it('should allow an applicationId to be provided upon construction', function() {
     var appId = 'some_app_id';
     var cred = new Credentials('KEY', 'SECRET', __dirname + '/private-test.key', appId);

--- a/test/Credentials-test.js
+++ b/test/Credentials-test.js
@@ -57,7 +57,7 @@ describe('Credentials Object', function() {
     expect(cred.privateKey).to.be.an.instanceof(Buffer);
   });
 
-  it('should support passing privateKey as a String', function() {
+  it('should support passing a privateKey of type string', function() {
     var key =
 `-----BEGIN PRIVATE KEY-----
 blah blah blah


### PR DESCRIPTION
The change moves from testing the type of `privateKey` using `instanceof privateKey` to instead using `typeof privateKey`. 

It would seem that if a file is loaded into an environment variable by something like foreman then the value is a string, but the variable is not a `String` object. So it's safer to use `typeof`.

Related information about this JavaScript-ness here http://stackoverflow.com/questions/203739/why-does-instanceof-return-false-for-some-literals

If accepted we should do a patch release.

p.s. ❤️ my spelling of this branch!