### PR TITLE
Check HTTP response `statusCode` and not `status`

### DIFF
--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -77,7 +77,7 @@ class HttpClient {
               if (isBinary) { responseData = Buffer.concat(responseData); }
 
               this.__parseReponse(
-                response.status,
+                response.statusCode,
                 response.headers['content-type'],
                 responseData,
                 method,


### PR DESCRIPTION
HttpClient does not pass error object to callback, because `status` variable always be `undefined`.