### PR TITLE
Fix/429 response handling

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -4,6 +4,7 @@ var config = {
   API_KEY: process.env.API_KEY || '',
   API_SECRET: process.env.API_SECRET || '',
   FROM_NUMBER: process.env.FROM_NUMBER || '',
+  ALT_TO_NUMBER: process.env.ALT_TO_NUMBER || '',
   TO_NUMBER: process.env.TO_NUMBER || '',
   APP_ID: process.env.APP_ID || '',
   PRIVATE_KEY: process.env.PRIVATE_KEY || '',

--- a/examples/ex-make-multiple-calls.js
+++ b/examples/ex-make-multiple-calls.js
@@ -1,0 +1,83 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY, 
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    {debug: config.DEBUG}
+  );
+
+  function callWithRetry(callRequest, callback, maxRetries, retryCount) {
+    retryCount = retryCount || 0;
+
+    nexmo.calls.create(callRequest, function(error, result) {
+        console.log('----------------------------');
+        console.log('call response returned');
+        console.log('error', JSON.stringify(error, null, 2));
+        console.log('result', JSON.stringify(result, null, 2));
+
+        if(error && error.statusCode === 429 && retryCount <= maxRetries) {
+          console.log('429 detected. Retrying after', error.headers['retry-after'], 'ms');
+          setTimeout(function() {
+            callWithRetry(callRequest, callback, maxRetries, ++retryCount);
+          }, error.headers['retry-after']);
+          
+        }
+        else {
+          callback(error, result);
+        }
+      });
+  }
+
+  const callsToMake = [
+    {
+      to: [{
+        type: 'phone',
+        number: config.TO_NUMBER
+      }],
+      from: {
+        type: 'phone',
+        number: config.FROM_NUMBER
+      },
+      answer_url: ['https://nexmo-community.github.io/ncco-examples/first_call_talk.json'],
+      event_url: ['http://requestb.in/wgapg3wg?to=' + config.TO_NUMBER]
+    },
+    {
+      to: [{
+        type: 'phone',
+        number: config.ALT_TO_NUMBER
+      }],
+      from: {
+        type: 'phone',
+        number: config.FROM_NUMBER
+      },
+      answer_url: ['https://nexmo-community.github.io/ncco-examples/first_call_talk.json'],
+      event_url: ['http://requestb.in/wgapg3wg?to=' + config.ALT_TO_NUMBER]
+    }
+  ];
+
+  const results = [];
+  function makeNextCall(error, result) {
+    if(error || result) {
+      results.push({error: error, result: result});
+    }
+
+    if(callsToMake.length > 0) {
+      var callRequest = callsToMake.shift();
+      callWithRetry(callRequest, makeNextCall, 1);
+    }
+    else {
+      console.log('--------------------------');
+      console.log('all calls completed', results);
+      console.log('--------------------------');
+      callback(null, results);
+    }
+  }
+
+  makeNextCall();
+
+};

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -79,7 +79,7 @@ class HttpClient {
               this.__parseResponse(
                 response,
                 responseData,
-                method,
+                endpoint.method,
                 callback
               );
             }
@@ -122,7 +122,7 @@ class HttpClient {
           const retryAfterMillis = (method === 'POST'? 1000/2 : 1000/5);
           headers['retry-after'] = retryAfterMillis;
         }
-        error = {statusCode: 429, body: data};
+        error = {body: data.join('')};
       } else if (status >= 400 || status < 200) {
         error = {body: JSON.parse(data.join('')), headers};
       } else if(method !== 'DELETE') {

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -305,4 +305,28 @@ describe('parseResponse', function() {
     expect(callback).was.calledWith(null, data);
   });
 
+  it ('should set a default retry-after of 200 for a GET with a 429 response', function() {
+    var callback = sinon.spy();
+    const headers = {};
+    const response = {statusCode: 429, headers: headers};
+    client.__parseResponse(response, [''], 'GET', callback);
+    expect(callback).was.calledWith({ statusCode: 429, body: '', headers: {'retry-after': 200}}, null);
+  });
+
+  it ('should set a default retry-after of 500 for a POST with a 429 response', function() {
+    var callback = sinon.spy();
+    const headers = {};
+    const response = {statusCode: 429, headers: headers};
+    client.__parseResponse(response, [''], 'POST', callback);
+    expect(callback).was.calledWith({ statusCode: 429, body: '', headers: {'retry-after': 500}}, null);
+  });
+
+  it ('should use the server returned retry-header with a 429 response', function() {
+    var callback = sinon.spy();
+    const headers = {'retry-after': 400};
+    const response = {statusCode: 429, headers: headers};
+    client.__parseResponse(response, [''], 'GET', callback);
+    expect(callback).was.calledWith({ statusCode: 429, body: '', headers: {'retry-after': 400}}, null);
+  });
+
 });

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -321,7 +321,7 @@ describe('parseResponse', function() {
     expect(callback).was.calledWith({ statusCode: 429, body: '', headers: {'retry-after': 500}}, null);
   });
 
-  it ('should use the server returned retry-header with a 429 response', function() {
+  it ('should use the server returned retry-after header with a 429 response', function() {
     var callback = sinon.spy();
     const headers = {'retry-after': 400};
     const response = {statusCode: 429, headers: headers};


### PR DESCRIPTION
Default `retry-after` are now correctly set to 200ms for GET and 500ms for POST requests.