### PR TITLE
Add ability to generate a sub token with no restrictions

### DIFF
--- a/examples/ex-generate-jwt.js
+++ b/examples/ex-generate-jwt.js
@@ -1,0 +1,16 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY,
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY,
+    },
+    {debug: config.DEBUG}
+  );
+
+  var jwt = nexmo.generateJwt();
+  console.log(jwt)
+};

--- a/examples/run-examples.js
+++ b/examples/run-examples.js
@@ -57,6 +57,7 @@ exampleFiles = [
   // 'ex-dtmf-to-call.js',
   'ex-get-apps.js',
   'ex-get-calls.js',
+  //'ex-generate-jwt.js',
   // 'ex-make-call.js',
   'ex-number-insight-basic.js',
   'ex-send-sms.js',

--- a/src/JwtGenerator.js
+++ b/src/JwtGenerator.js
@@ -22,7 +22,8 @@ class JwtGenerator {
 		
 		var toSign = {
 			'iat': claims.issuedAt || parseInt(Date.now()/1000, 10),
-			'jti': claims.jti || uuid.v1()
+			'jti': claims.jti || uuid.v1(),
+			'acl': { "paths": { "/**": {} } }
 		};
 		Object.keys(claims).forEach((key) => {
 			toSign[key] = claims[key];

--- a/test/JwtGenerator-test.js
+++ b/test/JwtGenerator-test.js
@@ -35,7 +35,7 @@ describe('JwtGenerator Object', function() {
       expect(token).to.be.a('string');
     });
 
-    it('should add jti and iat claims by default', function() {
+    it('should add jti iat and acl claims by default', function() {
       var testPrivateKey = fs.readFileSync(__dirname + '/private-test.key');
       var testPublicKey = fs.readFileSync(__dirname + '/public-test.key');
 
@@ -46,6 +46,7 @@ describe('JwtGenerator Object', function() {
 
       expect(decoded.jti).to.be.ok();
       expect(decoded.iat).to.be.ok();
+      expect(decoded.acl).to.be.ok();
     });
 
     it('should be possible to add additional claims', function() {


### PR DESCRIPTION
Add a jwt example
Modify jwt test

With this change, users will be able to generate a sub token with no restrictions.

Thank you @jacopomaroli for your help and suggestions for this change.

In addition to modifying the tests, I've also verified through https://jwt.io/ that a jwt generated with this will include in its payload:

```json
"acl": {
    "paths": {
      "/**": {}
    }
}
```