### PR TITLE
Handle 204 status code

### DIFF
--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -123,6 +123,8 @@ class HttpClient {
           headers['retry-after'] = retryAfterMillis;
         }
         error = {body: data.join('')};
+      } else if (status === 204) {
+        response = data;
       } else if (status >= 400 || status < 200) {
         error = {body: JSON.parse(data.join('')), headers};
       } else if(method !== 'DELETE') {

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -124,7 +124,7 @@ class HttpClient {
         }
         error = {body: data.join('')};
       } else if (status === 204) {
-        response = data;
+        response = null;
       } else if (status >= 400 || status < 200) {
         error = {body: JSON.parse(data.join('')), headers};
       } else if(method !== 'DELETE') {

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -271,6 +271,14 @@ describe('parseResponse', function() {
     expect(callback).was.calledWith({ statusCode: 404, body: { 'error' : 'error' }, headers: headers}, null);
   });
 
+  it ('should parse a 204 status code as a JSON object', function() {
+    var callback = sinon.spy();
+    const headers = {'content-type' : 'application/json'};
+    const response = {statusCode: 204, headers: headers};
+    client.__parseResponse(response, [''], 'GET', callback);
+    expect(callback).was.calledWith(null, ['']);
+  });
+
   it ('should parse a 200-299 status code as a JSON object', function() {
     var callback = sinon.spy();
     const response = {statusCode: 201, headers: {'content-type' : 'application/json'}};

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -271,12 +271,12 @@ describe('parseResponse', function() {
     expect(callback).was.calledWith({ statusCode: 404, body: { 'error' : 'error' }, headers: headers}, null);
   });
 
-  it ('should parse a 204 status code as a JSON object', function() {
+  it ('should parse a 204 status code as null', function() {
     var callback = sinon.spy();
     const headers = {'content-type' : 'application/json'};
     const response = {statusCode: 204, headers: headers};
     client.__parseResponse(response, [''], 'GET', callback);
-    expect(callback).was.calledWith(null, ['']);
+    expect(callback).was.calledWith(null, null);
   });
 
   it ('should parse a 200-299 status code as a JSON object', function() {


### PR DESCRIPTION
When updating a call a 204 response is returned (such as when hanging up an active call). Currently this is seen as an error by the lib but the action does perform correctly but doesn't provide any response body.

(Created again after messing up #154.)