### PR TITLE
Add support for the conversion endpoint

### DIFF
--- a/src/Conversion.js
+++ b/src/Conversion.js
@@ -1,0 +1,37 @@
+"use strict";
+
+import nexmo from "./index";
+
+class Conversion {
+  constructor(credentials, options) {
+    this.creds = credentials;
+    this.options = options;
+
+    // Used to facilitate testing of the call to the underlying object
+    this._nexmo = this.options.nexmoOverride || nexmo;
+
+    this._nexmo.initialize(
+      this.creds.apiKey,
+      this.creds.apiSecret,
+      this.options
+    );
+  }
+
+  voice(message_id, delivered, timestamp, callback) {
+    return this.submit("voice", message_id, delivered, timestamp, callback);
+  }
+
+  sms(message_id, delivered, timestamp, callback) {
+    return this.submit("sms", message_id, delivered, timestamp, callback);
+  }
+
+  submit(type, message_id, delivered, timestamp, callback) {
+    return this.options.api.postUseQueryString(
+      "/conversions/" + type,
+      { "message-id": message_id, delivered, timestamp },
+      this.options.api._addLimitedAccessMessageToErrors(callback, 402)
+    );
+  }
+}
+
+export default Conversion;

--- a/src/Nexmo.js
+++ b/src/Nexmo.js
@@ -12,6 +12,7 @@ import App from "./App";
 import Account from "./Account";
 import CallsResource from "./CallsResource";
 import FilesResource from "./FilesResource";
+import Conversion from "./Conversion";
 import HttpClient from "./HttpClient";
 import NullLogger from "./NullLogger";
 import ConsoleLogger from "./ConsoleLogger";
@@ -81,6 +82,7 @@ class Nexmo {
     this.account = new Account(this.credentials, this.options);
     this.calls = new CallsResource(this.credentials, this.options);
     this.files = new FilesResource(this.credentials, this.options);
+    this.conversion = new Conversion(this.credentials, this.options);
 
     /**
      * @deprecated Please use nexmo.applications

--- a/test/Conversion-test.js
+++ b/test/Conversion-test.js
@@ -1,0 +1,97 @@
+import Conversion from "../lib/Conversion";
+import Credentials from "../lib/Credentials";
+import HttpClient from "../lib/HttpClient";
+import NullLogger from "../lib/ConsoleLogger";
+
+import ResourceTestHelper from "./ResourceTestHelper";
+import sinon from "sinon";
+import chai, { expect } from "chai";
+import sinonChai from "sinon-chai";
+chai.use(sinonChai);
+
+describe("Conversion", function() {
+  beforeEach(function() {
+    var creds = Credentials.parse({
+      apiKey: "myKey",
+      apiSecret: "mySecret"
+    });
+
+    this.httpClientStub = new HttpClient(
+      {
+        logger: new NullLogger()
+      },
+      creds
+    );
+
+    sinon.stub(this.httpClientStub, "request");
+
+    var options = {
+      api: this.httpClientStub
+    };
+
+    this.conversion = new Conversion(creds, options);
+  });
+
+  describe("#submit", function() {
+    it("should call the correct endpoint", function(done) {
+      this.httpClientStub.request.yields(null, {});
+
+      var expectedRequestArgs = ResourceTestHelper.requestArgsMatch({
+        path:
+          "/conversions/foo?message-id=1234&delivered=1&timestamp=1513254618"
+      });
+
+      this.conversion.submit(
+        "foo",
+        "1234",
+        1,
+        1513254618,
+        function(err, data) {
+          expect(this.httpClientStub.request).to.have.been.calledWith(
+            sinon.match(expectedRequestArgs)
+          );
+
+          done();
+        }.bind(this)
+      );
+    });
+
+    it("returns a friendly error when not enabled", function(done) {
+      const mockError = {
+        status: 402
+      };
+
+      this.httpClientStub.request.yields(mockError, null);
+      this.conversion.sms("1234", 1, 1234567890, function(err, data) {
+        expect(err._INFO_).to.eql(
+          "This endpoint may need activating on your account. Please email support@nexmo.com for more information"
+        );
+        expect(data).to.eql(null);
+        done();
+      });
+    });
+  });
+
+  describe("#voice", function() {
+    it("calls the correct endpoint for voice", function() {
+      const submitStub = sinon.stub(this.conversion, "submit");
+      this.conversion.voice("1234", 1, 1513254618);
+      expect(submitStub).to.have.been.calledWith(
+        "voice",
+        "1234",
+        1,
+        1513254618
+      );
+      submitStub.restore();
+    });
+  });
+
+  describe("#sms", function() {
+    it("calls the correct endpoint for sms", function() {
+      const submitStub = sinon.stub(this.conversion, "submit");
+      this.conversion.sms("1234", 1, 1513254618);
+      expect(submitStub).to.have.been.calledWith("sms", "1234", 1, 1513254618);
+      submitStub.restore();
+    });
+  });
+});


### PR DESCRIPTION
This allows customers to provide feedback about their requests to help
Nexmo's adaptive routing system maximise deliverability.

It is opt-in and must be enabled on your account by the Nexmo support
team

Resolves #141