### PR TITLE
Add support for custom timeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Options are:
     info: function() {args...},
     warn: function() {args...}
   },
-  // Set a custom timeout for requests to Nexmo in milliseconds. Defaults to 30,000, ie. 30 seconds.
+  // Set a custom timeout for requests to Nexmo in milliseconds. Defaults to the standard for Node http requests, which is 120,000 ms.
   timeout: integer
 }
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Options are:
     log: function() {level, args...}
     info: function() {args...},
     warn: function() {args...}
-  }
+  },
+  // Set a custom timeout for requests to Nexmo in milliseconds. Defaults to 30,000, ie. 30 seconds.
+  timeout: integer
 }
 ```
 

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -14,6 +14,7 @@ class HttpClient {
       Accept: "application/json"
     };
     this.logger = options.logger;
+    this.timeout = options.timeout || 30 * 1000;
 
     if (options.userAgent) {
       this.headers["User-Agent"] = options.userAgent;
@@ -39,7 +40,8 @@ class HttpClient {
       port: this.port,
       path: endpoint.path,
       method: endpoint.method,
-      headers: Object.assign({}, this.headers)
+      headers: Object.assign({}, this.headers),
+      timeout: this.timeout
     };
 
     // Allow existing headers to be overridden
@@ -56,7 +58,7 @@ class HttpClient {
     if (options.port === 443) {
       request = this.https.request(options);
     } else {
-      request = http.request(options);
+      request = this.http.request(options);
     }
 
     request.end(endpoint.body);

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -14,7 +14,7 @@ class HttpClient {
       Accept: "application/json"
     };
     this.logger = options.logger;
-    this.timeout = options.timeout || 30 * 1000;
+    this.timeout = options.timeout;
 
     if (options.userAgent) {
       this.headers["User-Agent"] = options.userAgent;
@@ -40,9 +40,12 @@ class HttpClient {
       port: this.port,
       path: endpoint.path,
       method: endpoint.method,
-      headers: Object.assign({}, this.headers),
-      timeout: this.timeout
+      headers: Object.assign({}, this.headers)
     };
+
+    if (this.timeout !== undefined) {
+      options.timeout = this.timeout;
+    }
 
     // Allow existing headers to be overridden
     // Allow new headers to be added

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -40,7 +40,8 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 443
+        port: 443,
+        timeout: 30000
       })
       .returns(fakeRequest);
 
@@ -72,7 +73,8 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 80
+        port: 80,
+        timeout: 30000
       })
       .returns(fakeRequest);
 
@@ -104,7 +106,8 @@ describe("HttpClient Object", function() {
         host: "rest.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 80
+        port: 80,
+        timeout: 30000
       })
       .returns(fakeRequest);
 
@@ -136,7 +139,8 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/some_path",
-        port: 80
+        port: 80,
+        timeout: 30000
       })
       .returns(fakeRequest);
 
@@ -168,13 +172,47 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "POST",
         path: "/api",
-        port: 443
+        port: 443,
+        timeout: 30000
       })
       .returns(fakeRequest);
 
     var client = new HttpClient({
       https: fakeHttp,
       logger: logger
+    });
+
+    client.request(
+      {
+        host: "api.nexmo.com",
+        path: "/api"
+      },
+      "POST",
+      {
+        some: "data"
+      }
+    );
+  });
+
+  it("should be possible to set the timeout", function() {
+    var mock = sinon.mock(fakeHttp);
+    mock
+      .expects("request")
+      .once()
+      .withArgs({
+        headers: defaultHeaders,
+        host: "api.nexmo.com",
+        method: "POST",
+        path: "/api",
+        port: 443,
+        timeout: 5000
+      })
+      .returns(fakeRequest);
+
+    var client = new HttpClient({
+      https: fakeHttp,
+      logger: logger,
+      timeout: 5000
     });
 
     client.request(
@@ -199,7 +237,8 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "POST",
         path: "/api",
-        port: 443
+        port: 443,
+        timeout: 30000
       })
       .returns(fakeRequest);
 
@@ -260,7 +299,8 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "POST",
         path: "/api",
-        port: 443
+        port: 443,
+        timeout: 30000
       })
       .returns(fakeRequest);
 
@@ -423,7 +463,8 @@ describe("parseResponse", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 80
+        port: 80,
+        timeout: 30000
       })
       .returns(fakeRequest);
 

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -40,8 +40,7 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 443,
-        timeout: 30000
+        port: 443
       })
       .returns(fakeRequest);
 
@@ -73,8 +72,7 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 80,
-        timeout: 30000
+        port: 80
       })
       .returns(fakeRequest);
 
@@ -106,8 +104,7 @@ describe("HttpClient Object", function() {
         host: "rest.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 80,
-        timeout: 30000
+        port: 80
       })
       .returns(fakeRequest);
 
@@ -139,8 +136,7 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/some_path",
-        port: 80,
-        timeout: 30000
+        port: 80
       })
       .returns(fakeRequest);
 
@@ -172,8 +168,7 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "POST",
         path: "/api",
-        port: 443,
-        timeout: 30000
+        port: 443
       })
       .returns(fakeRequest);
 
@@ -237,8 +232,7 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "POST",
         path: "/api",
-        port: 443,
-        timeout: 30000
+        port: 443
       })
       .returns(fakeRequest);
 
@@ -299,8 +293,7 @@ describe("HttpClient Object", function() {
         host: "api.nexmo.com",
         method: "POST",
         path: "/api",
-        port: 443,
-        timeout: 30000
+        port: 443
       })
       .returns(fakeRequest);
 
@@ -463,8 +456,7 @@ describe("parseResponse", function() {
         host: "api.nexmo.com",
         method: "GET",
         path: "/api",
-        port: 80,
-        timeout: 30000
+        port: 80
       })
       .returns(fakeRequest);
 


### PR DESCRIPTION
This adds support for adding a custom timeout value. Right now the default Node timeout of 120,000ms is used, which for our needs is too long. 

The default is now 30,000ms, which is more reasonable for a use case like this in my opinion, but feel free to change this.