### PR TITLE
Count Content-Length in actual bytes

### DIFF
--- a/src/CallsResource.js
+++ b/src/CallsResource.js
@@ -57,7 +57,7 @@ class CallsResource {
       body: params,
       headers: {
         "Content-Type": "application/json",
-        "Content-Length": params.length,
+        "Content-Length": Buffer.byteLength(params),
         Authorization: `Bearer ${this.creds.generateJwt()}`
       }
     };
@@ -115,7 +115,7 @@ class CallsResource {
       body: params,
       headers: {
         "Content-Type": "application/json",
-        "Content-Length": params.length,
+        "Content-Length": Buffer.byteLength(params),
         Authorization: `Bearer ${this.creds.generateJwt()}`
       }
     };

--- a/src/DtmfResource.js
+++ b/src/DtmfResource.js
@@ -36,7 +36,7 @@ class DtmfResource {
       body: params,
       headers: {
         "Content-Type": "application/json",
-        "Content-Length": params.length,
+        "Content-Length": Buffer.byteLength(params),
         Authorization: `Bearer ${this.creds.generateJwt()}`
       }
     };

--- a/src/StreamResource.js
+++ b/src/StreamResource.js
@@ -36,7 +36,7 @@ class StreamResource {
       body: params,
       headers: {
         "Content-Type": "application/json",
-        "Content-Length": params.length,
+        "Content-Length": Buffer.byteLength(params),
         Authorization: `Bearer ${this.creds.generateJwt()}`
       }
     };

--- a/src/TalkResource.js
+++ b/src/TalkResource.js
@@ -36,7 +36,7 @@ class TalkResource {
       body: params,
       headers: {
         "Content-Type": "application/json",
-        "Content-Length": params.length,
+        "Content-Length": Buffer.byteLength(params),
         Authorization: `Bearer ${this.creds.generateJwt()}`
       }
     };

--- a/test/CallResource-test.js
+++ b/test/CallResource-test.js
@@ -33,10 +33,25 @@ describe("CallsResource", () => {
   });
 
   it("should allow a call to be created", () => {
-    var params = {};
+    var params = {
+      to: {
+        type: "websocket",
+        uri: "wss://example.com/socket",
+        "content-type": "audio/l16;rate=16000",
+        headers: {
+          "utf-8": "✅"
+        }
+      }
+    };
     calls.create(params, emptyCallback);
 
-    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params);
+    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": 124
+      }
+    });
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match(expectedRequestArgs),
       emptyCallback
@@ -105,13 +120,21 @@ describe("CallsResource", () => {
   it("should allow a call to be updated", () => {
     const callId = "2342342-lkjhlkjh-32423";
     var params = {
-      action: "hangup"
+      action: "hangup",
+      destination: {
+        type: "ncco",
+        url: ["http://exémple.com/ncco.json"]
+      }
     };
     calls.update(callId, params, emptyCallback);
 
     var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
       method: "PUT",
-      path: `${CallsResource.PATH}/${callId}`
+      path: `${CallsResource.PATH}/${callId}`,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": 89
+      }
     });
 
     expect(httpClientStub.request).to.have.been.calledWith(

--- a/test/DtmfResource-test.js
+++ b/test/DtmfResource-test.js
@@ -39,7 +39,11 @@ describe("DtmfResource", () => {
 
     var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
       path: DtmfResource.PATH.replace("{call_uuid}", callId),
-      method: "PUT"
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": 20
+      }
     });
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match(expectedRequestArgs),

--- a/test/ResourceTestHelper.js
+++ b/test/ResourceTestHelper.js
@@ -60,6 +60,7 @@ class ResourceTestHelper {
         if (k === "Authorization") {
           return true;
         }
+
         match = match && expected.headers[k] === actual.headers[k];
       });
 

--- a/test/StreamResource-test.js
+++ b/test/StreamResource-test.js
@@ -32,14 +32,19 @@ describe("StreamResource", () => {
   it("should allow a stream to be started", () => {
     const callId = "2342342-lkjhlkjh-32423";
     var params = {
-      stream_url: "https://example.com/test.mp3" // eslint-disable-line camelcase
+      stream_url: "https://example.com/▶tést.mp3" // eslint-disable-line camelcase
     }; // eslint-disable-line camelcase
     stream.start(callId, params, emptyCallback);
 
     var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
       path: StreamResource.PATH.replace("{call_uuid}", callId),
-      method: "PUT"
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": 49
+      }
     });
+
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match(expectedRequestArgs),
       emptyCallback

--- a/test/TalkResource-test.js
+++ b/test/TalkResource-test.js
@@ -38,7 +38,32 @@ describe("TalkResource", () => {
 
     var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
       path: TalkResource.PATH.replace("{call_uuid}", callId),
-      method: "PUT"
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": 17
+      }
+    });
+    expect(httpClientStub.request).to.have.been.calledWith(
+      sinon.match(expectedRequestArgs),
+      emptyCallback
+    );
+  });
+
+  it("should be able to start a talk with unicode characters", () => {
+    const callId = "2342342-lkjhlkjh-32423";
+    var params = {
+      text: "Alô 😊!"
+    };
+    talk.start(callId, params, emptyCallback);
+
+    var expectedRequestArgs = ResourceTestHelper.requestArgsMatch(params, {
+      path: TalkResource.PATH.replace("{call_uuid}", callId),
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": 21
+      }
     });
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match(expectedRequestArgs),


### PR DESCRIPTION
Hello! I saw the issue #196 and immediately went to look into the code to figure out why it was happening. Found out it was an issue with UTF-8 data, so I fixed it using the [node documentation examples on how to use the `http` module](https://nodejs.org/docs/latest-v9.x/api/http.html#http_response_writehead_statuscode_statusmessage_headers):

```javascript
const body = 'hello world';
response.writeHead(200, {
  'Content-Length': Buffer.byteLength(body),
  'Content-Type': 'text/plain' });
```

Using `byteLength` rather than string `length` seems to fix the problem, since it was counting characters wrong for UTF-8 encoded data.

I can provide tests for this, but I don't know where exactly they would fit in since there are multiple places in the code where the change has been made.