### PR TITLE
 Make TravisCI Run Tests on Multiple Operating Systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the default behavior for line endings
+* text=auto
+* text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
+os:
+  - windows
+  - linux
+  - osx
 language: node_js
 node_js:
-- 4
-- 6
-- 8
-- lts/*
-- node
+  - 4
+  - 6
+  - 8
+  - lts/*
+  - node
 deploy:
   provider: npm
   email: devrel@nexmo.com


### PR DESCRIPTION
Summary
As of 11 October 2018, Travis CI now supports Windows build environment. In light of #213  this PR enables multiple OS build environments (Linux, Windows, and MacOS).

The Windows build currently fails because #213. They should build correctly when this issue is resolved.