### PR TITLE
Initial pass at media API implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,13 @@ Also see the [Nexmo Node Quickstarts repo](https://github.com/nexmo-community/ne
     * [x] Buy
     * [x] Cancel
     * [x] Update
+* Media
+  * [x] Upload
+  * [x] Download
+  * [x] Search
+  * [x] Get
+  * [x] Update
+  * [x] Delete
 * Voice (Deprecated)
   * [x] Outbound Calls
   * [ ] Inbound Call Webhook

--- a/examples/config.js
+++ b/examples/config.js
@@ -6,6 +6,7 @@ var config = {
   FROM_NUMBER: process.env.FROM_NUMBER || '',
   ALT_TO_NUMBER: process.env.ALT_TO_NUMBER || '',
   TO_NUMBER: process.env.TO_NUMBER || '',
+  MEDIA_ID: process.env.MEDIA_ID || '',
   APP_ID: process.env.APP_ID || '',
   PRIVATE_KEY: process.env.PRIVATE_KEY || '',
   DEBUG: process.env.DEBUG === 'true'

--- a/examples/ex-media-delete.js
+++ b/examples/ex-media-delete.js
@@ -1,0 +1,18 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY,
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    {debug: config.DEBUG}
+  );
+
+  nexmo.media.delete(config.MEDIA_ID, function(err, data) {
+    if (err) { throw err; }
+    console.log(data);
+  });
+};

--- a/examples/ex-media-download.js
+++ b/examples/ex-media-download.js
@@ -1,0 +1,18 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY,
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    {debug: config.DEBUG}
+  );
+
+  nexmo.media.download(config.MEDIA_ID, function(err, data) {
+    if (err) { throw err; }
+    console.log(data.toString());
+  });
+};

--- a/examples/ex-media-get.js
+++ b/examples/ex-media-get.js
@@ -1,0 +1,18 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY,
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    {debug: config.DEBUG}
+  );
+
+  nexmo.media.get(config.MEDIA_ID, function(err, data) {
+    if (err) { throw err; }
+    console.log(data);
+  });
+};

--- a/examples/ex-media-search.js
+++ b/examples/ex-media-search.js
@@ -1,0 +1,18 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY,
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    {debug: config.DEBUG}
+  );
+
+  nexmo.media.search({ page_size: 1, page_index: 1 }, function(err, data) {
+    if (err) { throw err; }
+    console.log(data);
+  });
+};

--- a/examples/ex-media-update.js
+++ b/examples/ex-media-update.js
@@ -1,0 +1,18 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY,
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    {debug: config.DEBUG}
+  );
+
+  nexmo.media.update(config.MEDIA_ID, { public_item: true }, function(err, data) {
+    if (err) { throw err; }
+    console.log(data);
+  });
+};

--- a/examples/ex-media-upload.js
+++ b/examples/ex-media-upload.js
@@ -1,0 +1,25 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+      apiKey: config.API_KEY,
+      apiSecret: config.API_SECRET,
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    {debug: config.DEBUG}
+  );
+
+  nexmo.media.upload(
+    {
+      //file: "/path/to/file", // If you want to upload a file instead of fetching a URL, set this instead
+      url: "https://www.nexmo.com/wp-content/uploads/2016/07/nexmo_vonage_color.jpg",
+      info: { test: "content" }
+    },
+    function(err, data) {
+      if (err) { throw err; }
+      console.log(data);
+    }
+  );
+};

--- a/package.json
+++ b/package.json
@@ -29,16 +29,13 @@
   ],
   "scripts": {
     "compile": "./node_modules/.bin/babel -d lib src/ -s inline",
-
     "test": "npm run test-no-lint",
     "test-coverage": "cross-env NODE_ENV=test nyc mocha",
     "test-coverage-html": "cross-env NODE_ENV=test nyc --reporter html mocha",
     "test-no-lint": "npm run compile && mocha --compilers ./node_modules/.bin/_mocha --compilers js:babel-register ./test/*-test.js",
     "test-watch": "nodemon --watch src --watch test -x 'npm run test-no-lint'",
-
     "lint": "eslint src test",
     "lint-fix": "eslint --fix src test",
-
     "prepublish": "npm run compile",
     "pretest": "npm run lint"
   },
@@ -69,6 +66,7 @@
   },
   "dependencies": {
     "jsonwebtoken": "^7.1.9",
+    "request": "^2.83.0",
     "uuid": "^2.0.2"
   },
   "license": "MIT"

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -1,5 +1,6 @@
 var https = require("https");
 var http = require("http");
+var request = require("request");
 var querystring = require("querystring");
 
 class HttpClient {
@@ -15,13 +16,14 @@ class HttpClient {
     };
     this.logger = options.logger;
     this.timeout = options.timeout;
+    this.requestLib = request;
 
     if (options.userAgent) {
       this.headers["User-Agent"] = options.userAgent;
     }
   }
 
-  request(endpoint, method, callback) {
+  request(endpoint, method, callback, skipJsonParsing = false) {
     if (typeof method === "function") {
       callback = method;
       endpoint.method = endpoint.method || "GET";
@@ -92,7 +94,8 @@ class HttpClient {
             response,
             responseData,
             endpoint.method,
-            callback
+            callback,
+            skipJsonParsing
           );
         }
       });
@@ -111,7 +114,7 @@ class HttpClient {
     });
   }
 
-  __parseResponse(httpResponse, data, method, callback) {
+  __parseResponse(httpResponse, data, method, callback, skipJsonParsing) {
     const isArrayOrBuffer = data instanceof Array || data instanceof Buffer;
     if (!isArrayOrBuffer) {
       throw new Error("data should be of type Array or Buffer");
@@ -143,7 +146,11 @@ class HttpClient {
       } else if (status >= 400 || status < 200) {
         error = { body: JSON.parse(data.join("")), headers };
       } else if (method !== "DELETE") {
-        response = JSON.parse(data.join(""));
+        if (!!skipJsonParsing) {
+          response = data.join("");
+        } else {
+          response = JSON.parse(data.join(""));
+        }
       } else {
         response = data;
       }
@@ -184,7 +191,7 @@ class HttpClient {
     };
   }
 
-  get(path, params, callback) {
+  get(path, params, callback, useJwt = false) {
     if (!callback) {
       if (typeof params == "function") {
         callback = params;
@@ -193,19 +200,88 @@ class HttpClient {
     }
 
     params = params || {};
-    params["api_key"] = this.credentials.apiKey;
-    params["api_secret"] = this.credentials.apiSecret;
+    if (!useJwt) {
+      params["api_key"] = this.credentials.apiKey;
+      params["api_secret"] = this.credentials.apiSecret;
+    }
 
     path = path + "?" + querystring.stringify(params);
 
-    this.request({ path: path }, "GET", callback);
+    const headers = { "Content-Type": "application/json" };
+    if (useJwt) {
+      headers["Authorization"] = `Bearer ${this.credentials.generateJwt()}`;
+    }
+
+    this.request({ path: path, headers }, "GET", callback);
   }
 
-  post(path, params, callback) {
-    let qs = {
-      api_key: this.credentials.apiKey,
-      api_secret: this.credentials.apiSecret
-    };
+  delete(path, callback, useJwt) {
+    let params = {};
+    if (!useJwt) {
+      params["api_key"] = this.credentials.apiKey;
+      params["api_secret"] = this.credentials.apiSecret;
+    }
+
+    path = path + "?" + querystring.stringify(params);
+
+    this.request({ path: path }, "DELETE", callback);
+  }
+
+  postFile(path, options, callback, useJwt) {
+    let qs = {};
+    if (!useJwt) {
+      qs["api_key"] = this.credentials.apiKey;
+      qs["api_secret"] = this.credentials.apiSecret;
+    }
+
+    if (Object.keys(qs).length) {
+      let joinChar = "?";
+      if (path.indexOf(joinChar) !== -1) {
+        joinChar = "&";
+      }
+      path = path + joinChar + querystring.stringify(qs);
+    }
+
+    const file = options.file;
+    delete options.file; // We don't send this as metadata
+
+    const formData = {};
+
+    if (file) {
+      formData["filedata"] = {
+        value: file,
+        options: {
+          filename: options.filename || null
+        }
+      };
+    }
+
+    if (options.info) {
+      formData.info = JSON.stringify(options.info);
+    }
+
+    if (options.url) {
+      formData.url = options.url;
+    }
+
+    this.requestLib.post(
+      {
+        url: "https://" + this.host + path,
+        formData: formData,
+        headers: {
+          Authorization: `Bearer ${this.credentials.generateJwt()}`
+        }
+      },
+      callback
+    );
+  }
+
+  post(path, params, callback, useJwt) {
+    let qs = {};
+    if (!useJwt) {
+      qs["api_key"] = this.credentials.apiKey;
+      qs["api_secret"] = this.credentials.apiSecret;
+    }
 
     let joinChar = "?";
     if (path.indexOf(joinChar) !== -1) {
@@ -221,10 +297,12 @@ class HttpClient {
     );
   }
 
-  postUseQueryString(path, params, callback) {
+  postUseQueryString(path, params, callback, useJwt) {
     params = params || {};
-    params["api_key"] = this.credentials.apiKey;
-    params["api_secret"] = this.credentials.apiSecret;
+    if (!useJwt) {
+      params["api_key"] = this.credentials.apiKey;
+      params["api_secret"] = this.credentials.apiSecret;
+    }
 
     path = path + "?" + querystring.stringify(params);
 

--- a/src/Media.js
+++ b/src/Media.js
@@ -1,0 +1,134 @@
+"use strict";
+
+import nexmo from "./index";
+import fs from "fs";
+import querystring from "querystring";
+
+class Media {
+  static get PATH() {
+    return "/v3/media";
+  }
+
+  constructor(credentials, options) {
+    this.creds = credentials;
+    this.options = options;
+
+    // Used to facilitate testing of the call to the underlying object
+    this._nexmo = this.options.nexmoOverride || nexmo;
+
+    this._nexmo.initialize(
+      this.creds.apiKey,
+      this.creds.apiSecret,
+      this.options
+    );
+  }
+
+  upload(opts, callback) {
+    opts = opts || {};
+    if (!opts.file && !opts.url) {
+      throw new Error(
+        "You must provide either 'file' or 'url' to upload a file"
+      );
+    }
+
+    if (opts.file) {
+      opts.file = fs.createReadStream(opts.file);
+    }
+    return this.options.api.postFile(
+      Media.PATH,
+      opts,
+      function(err, response, body) {
+        if (err) {
+          return callback(err);
+        }
+
+        let location = "";
+        if (response && response.headers) {
+          location = response.headers.location;
+        }
+
+        return callback(null, location);
+      },
+      true
+    );
+  }
+
+  search(options, callback) {
+    if (typeof options == "function" && !callback) {
+      callback = options;
+      options = {};
+    }
+
+    options = options || {};
+
+    return this._makeRequest("GET", Media.PATH, options, {}, callback);
+  }
+
+  // If If-Modified-Since header is provided and the data hasn't changed, the
+  // user will receive an empty body in the callback, NOT an error
+  download(id, headers, callback) {
+    if (!callback && typeof headers == "function") {
+      callback = headers;
+      headers = {};
+    }
+
+    return this._makeRequest(
+      "GET",
+      `${Media.PATH}/${id}`,
+      {},
+      headers,
+      callback,
+      true
+    );
+  }
+
+  delete(id, callback) {
+    return this._makeRequest("DELETE", `${Media.PATH}/${id}`, {}, {}, callback);
+  }
+
+  get(id, callback) {
+    return this._makeRequest(
+      "GET",
+      `${Media.PATH}/${id}/info`,
+      {},
+      {},
+      callback
+    );
+  }
+
+  update(id, opts, callback) {
+    return this._makeRequest(
+      "PUT",
+      `${Media.PATH}/${id}/info`,
+      opts,
+      {},
+      callback
+    );
+  }
+
+  _makeRequest(verb, path, options, headers, callback, skipJsonParsing) {
+    headers = Object.assign(
+      {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.creds.generateJwt()}`
+      },
+      headers
+    );
+
+    let req = {};
+    if (verb.toUpperCase() === "GET") {
+      if (Object.keys(options).length) {
+        path = path + "?" + querystring.stringify(options);
+      }
+    } else {
+      req["body"] = JSON.stringify(options);
+    }
+
+    req["path"] = path;
+    req["headers"] = headers;
+
+    return this.options.api.request(req, verb, callback, skipJsonParsing);
+  }
+}
+
+export default Media;

--- a/src/Nexmo.js
+++ b/src/Nexmo.js
@@ -13,6 +13,7 @@ import Account from "./Account";
 import CallsResource from "./CallsResource";
 import FilesResource from "./FilesResource";
 import Conversion from "./Conversion";
+import Media from "./Media";
 import HttpClient from "./HttpClient";
 import NullLogger from "./NullLogger";
 import ConsoleLogger from "./ConsoleLogger";
@@ -83,6 +84,7 @@ class Nexmo {
     this.calls = new CallsResource(this.credentials, this.options);
     this.files = new FilesResource(this.credentials, this.options);
     this.conversion = new Conversion(this.credentials, this.options);
+    this.media = new Media(this.credentials, this.options);
 
     /**
      * @deprecated Please use nexmo.applications

--- a/test/HttpClient-test.js
+++ b/test/HttpClient-test.js
@@ -397,6 +397,17 @@ describe("parseResponse", function() {
     );
   });
 
+  it("should not error with invalid JSON if parsing is disabled", function() {
+    var callback = sinon.spy();
+    const response = {
+      statusCode: 200,
+      headers: { "content-type": "application/json" }
+    };
+    const data = "not_json";
+    client.__parseResponse(response, [data], "GET", callback, true);
+    expect(callback).was.calledWith(null, data);
+  });
+
   it("should parse binary data", function() {
     var callback = sinon.spy();
     var data = new Buffer("data");

--- a/test/Media-test.js
+++ b/test/Media-test.js
@@ -1,0 +1,87 @@
+import Media from "../lib/Media";
+import { expect, sinon, TestUtils } from "./NexmoTestUtils";
+
+describe("Media", function() {
+  beforeEach(function() {
+    this.httpClientStub = TestUtils.getHttpClient();
+    sinon.stub(this.httpClientStub, "request");
+    sinon.stub(this.httpClientStub.requestLib, "post");
+    this.media = new Media(TestUtils.getCredentials(), {
+      api: this.httpClientStub
+    });
+  });
+
+  afterEach(function() {
+    this.httpClientStub.request.restore();
+    this.httpClientStub.requestLib.post.restore();
+  });
+
+  describe("#search", function() {
+    it("should default to no parameters", function() {
+      return expect(this.media)
+        .method("search")
+        .to.get.url(Media.PATH);
+    });
+
+    it("should pass through supplied parameters", function() {
+      return expect(this.media)
+        .method("search")
+        .withParams({ order: "ascending", page_size: 11 })
+        .to.get.url(`${Media.PATH}?order=ascending&page_size=11`);
+    });
+  });
+
+  describe("#download", function() {
+    it("should call the correct URL", function() {
+      return expect(this.media)
+        .method("download")
+        .withParams("ABC123")
+        .to.get.url(`${Media.PATH}/ABC123`);
+    });
+  });
+
+  describe("#get", function() {
+    it("should call the correct URL", function() {
+      return expect(this.media)
+        .method("get")
+        .withParams("ABC123")
+        .to.get.url(`${Media.PATH}/ABC123/info`);
+    });
+  });
+
+  describe("#delete", function() {
+    it("should call the correct URL", function() {
+      return expect(this.media)
+        .method("delete")
+        .withParams("ABC123")
+        .to.delete.url(`${Media.PATH}/ABC123`);
+    });
+  });
+
+  describe("#upload", function() {
+    // @TODO Add assertions for POST body
+    // @TODO Add mocks for request
+    it("should call the correct URL (file provided)", function() {
+      return expect(this.media)
+        .method("upload")
+        .withParams({ file: "/dev/null" })
+        .to.postFile.to.url("/v3/media");
+    });
+
+    it("should call the correct URL (url provided)", function() {
+      return expect(this.media)
+        .method("upload")
+        .withParams({ url: "http://example.com" })
+        .to.postFile.to.url("/v3/media");
+    });
+  });
+
+  describe("#update", function() {
+    it("should call the correct URL", function() {
+      return expect(this.media)
+        .method("update")
+        .withParams("ABC123", { public_item: true })
+        .to.put.to.url("/v3/media/ABC123/info");
+    });
+  });
+});

--- a/test/NexmoChai.js
+++ b/test/NexmoChai.js
@@ -12,6 +12,19 @@ module.exports = function(chai, utils) {
     this._httpMethod = "POST";
   });
 
+  utils.addProperty(chai.Assertion.prototype, "postFile", function() {
+    this._httpMethod = "POST";
+    this._isMultipartPost = true;
+  });
+
+  utils.addProperty(chai.Assertion.prototype, "put", function() {
+    this._httpMethod = "PUT";
+  });
+
+  utils.addProperty(chai.Assertion.prototype, "delete", function() {
+    this._httpMethod = "DELETE";
+  });
+
   utils.addChainableMethod(chai.Assertion.prototype, "method", function(
     method
   ) {
@@ -22,23 +35,33 @@ module.exports = function(chai, utils) {
   });
 
   utils.addMethod(chai.Assertion.prototype, "url", function(url) {
+    let spy;
+
     return new Promise(resolve => {
       const callback = (err, data) => {
-        if (!this._httpClient.request.args) {
+        if (!spy.args) {
           throw new Error("This assertion should only be used on Sinon spies");
         }
-        if (!this._httpClient.request.args[0]) {
+        if (!spy.args[0]) {
           throw new Error(
             "Spy was never called; cannot access arguments to check URL"
           );
         }
 
-        let args = this._httpClient.request.args[0];
+        let args = spy.args[0];
+
+        const isFilePost = args[0].formData ? true : false;
 
         // If we set a HTTP method property, let's assert that the correct
         // one was used
         if (this._httpMethod) {
           let calledVerb = args[1];
+
+          // It may be a file POST
+          if (isFilePost) {
+            calledVerb = "POST";
+          }
+
           const verb = new chai.Assertion(calledVerb.toUpperCase());
           verb.assert(
             verb._obj === this._httpMethod,
@@ -47,8 +70,25 @@ module.exports = function(chai, utils) {
           );
         }
 
+        // If we were expecting a multipart post, make sure we got one
+        if (this._multipartPost) {
+          const classMethod = new chai.Assertion(this._classMethod);
+          classMethod.assert(
+            classMethod._obj === "postFile",
+            "expected HTTPClient method called #{this} to match '" +
+              this._httpMethod +
+              "'",
+            "expected HTTPClient method called #{this} to not match '" +
+              this._httpMethod +
+              "'"
+          );
+        }
+
         // Next up, let's check that the path we called is what we expected
         let calledPath = args[0].path;
+        if (isFilePost) {
+          calledPath = args[0].url.split("nexmo.com")[1];
+        }
 
         // We strip api_key and api_secret out of `path` so that our tests
         // only look for specific parameters
@@ -63,6 +103,7 @@ module.exports = function(chai, utils) {
         }
 
         // Make our assertion
+        // Next up, let's check that the path we called is what we expected
         const path = new chai.Assertion(calledPath);
         path.assert(
           path._obj === url,
@@ -80,7 +121,14 @@ module.exports = function(chai, utils) {
 
       // Stub our HTTPClient call so that we can capture it
       this._httpClient = this._obj.options.rest || this._obj.options.api;
-      this._httpClient.request.yields(null, {});
+
+      if (this._isMultipartPost) {
+        spy = this._httpClient.requestLib.post;
+      } else {
+        spy = this._httpClient.request;
+      }
+
+      spy.yields(null, {});
 
       let m = this._obj[this._classMethod];
       m.apply(this._obj, this._params);

--- a/test/NexmoTestUtils.js
+++ b/test/NexmoTestUtils.js
@@ -11,10 +11,17 @@ chai.use(nexmoChai);
 
 const TestUtils = {
   getCredentials: function() {
-    return Credentials.parse({
+    var creds = Credentials.parse({
       apiKey: "myKey",
       apiSecret: "mySecret"
     });
+
+    // Overwrite JWT generation for tests
+    creds.generateJwt = function() {
+      return "ThisIsAJWT";
+    };
+
+    return creds;
   },
   getHttpClient: function() {
     const httpClient = new HttpClient(


### PR DESCRIPTION
There's a lot of room for improvement, but there's enough here to at
least try out the API.

* I've added `request` to handle the multipart form data for us. This
is the first step towards using `request` as our main HTTP client
* Media._makeRequest is required as Content-Type must be application/json
for all requests
* I've added a flag (`skipJsonDecoding`) to HTTPClient to allow us to
download a raw response (required for `media.download()`
out the mocks for `request`
* `media.download` implements both `If-Modified-Since` and
`If-None-Match` - https://ea.developer.nexmo.com/api/media#download-media-file
- but it is not documented. This is functionality we'll only expose if
people explicitly ask for it.
* Add support for mocking `request` when posting a file.  We check specifically
for the `postFile` method for now as that's the only thing that uses `request`.
This will need refactoring if we move away from HTTPClient in the future
* Add examples for Media API + supported list to README