### PR TITLE
Updated Advanced Number Insights in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ nexmo.numberInsight.get({level: 'standard', number: '1-234-567-8900'}, callback)
 ### Advanced
 
 ```js
-nexmo.numberInsight.get({level: 'advanced', number: NUMBER}, callback);
+nexmo.numberInsight.get({level: 'advancedSync', number: NUMBER}, callback);
 ```
 
 For more information check the documentation at https://developer.nexmo.com/number-insight/building-blocks/number-insight-advanced/node


### PR DESCRIPTION
The [source code](https://github.com/Nexmo/nexmo-node/blob/master/src/NumberInsight.js#L84) points `level: 'advanced'` to the async version of number insights, which is not correctly reflected in the README.

This is also the case in the examples on the website:

``` js
// BAD
nexmo.numberInsight.get({
  level: 'advanced'
  // ...
});

// GOOD
nexmo.numberInsight.get({
  level: 'advancedSync'
  // ...
});
```