### PR TITLE
- Added extra param to Channel and Dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ const nexmo = new Nexmo({
 Both of these objects expose the following methods:
 
 * `get(path, params, callback, useJwt)` (`params` is the query string to use)
-* `post(path, params, callback, useJwt)` (`params` is the POST body to send)
+* `post(path, params, callback, useJwt, useBasicAuth, headers = {})` (`params` is the POST body to send)
 * `postUseQueryString(path, params, callback, useJwt)` (`params` is the query string to use)
 * `delete(path, callback, useJwt)`
 

--- a/src/Channel.js
+++ b/src/Channel.js
@@ -23,16 +23,21 @@ class Channel {
     );
   }
 
-  send(to, from, message, callback) {
+  send(to, from, message, callback, opts = {}) {
     const params = {
       to: to,
       from: from,
       message: message
     };
 
-    return this.options.api.post(Channel.PATH, params, callback, true, {
-      "Content-Type": "application/json"
-    });
+    return this.options.api.post(
+      Channel.PATH,
+      params,
+      callback,
+      !opts.useBasicAuth,
+      opts.useBasicAuth,
+      { "Content-Type": "application/json" }
+    );
   }
 }
 

--- a/src/Dispatch.js
+++ b/src/Dispatch.js
@@ -23,15 +23,20 @@ class Dispatch {
     );
   }
 
-  create(template, workflow, callback) {
+  create(template, workflow, callback, opts = {}) {
     const params = {
       template: template,
       workflow: workflow
     };
 
-    return this.options.api.post(Dispatch.PATH, params, callback, true, {
-      "Content-Type": "application/json"
-    });
+    return this.options.api.post(
+      Dispatch.PATH,
+      params,
+      callback,
+      !opts.useBasicAuth,
+      opts.useBasicAuth,
+      { "Content-Type": "application/json" }
+    );
   }
 }
 

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -290,9 +290,9 @@ class HttpClient {
     );
   }
 
-  post(path, params, callback, useJwt, headers) {
+  post(path, params, callback, useJwt, useBasicAuth, headers = {}) {
     let qs = {};
-    if (!useJwt) {
+    if (!useJwt && !useBasicAuth) {
       qs["api_key"] = this.credentials.apiKey;
       qs["api_secret"] = this.credentials.apiSecret;
     }
@@ -304,9 +304,14 @@ class HttpClient {
 
     path = path + joinChar + querystring.stringify(qs);
 
-    headers = headers || {};
     if (useJwt) {
       headers["Authorization"] = `Bearer ${this.credentials.generateJwt()}`;
+    }
+
+    if (useBasicAuth) {
+      headers["Authorization"] = `Basic ${Buffer.from(
+        this.credentials.apiKey + ":" + this.credentials.apiSecret
+      ).toString("base64")}`;
     }
 
     let encodedParams;

--- a/test/Channel-test.js
+++ b/test/Channel-test.js
@@ -52,5 +52,56 @@ describe("Channel", function() {
         done();
       });
     });
+
+    it("uses JWT auth by default", function(done) {
+      const postMock = this.sandbox.mock(this.httpClientStub);
+      postMock
+        .expects("post")
+        .once()
+        .withArgs(
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match.any,
+          true,
+          undefined
+        )
+        .yields(null, []);
+
+      this.channel.send(
+        { type: "sms", number: "1234567890" },
+        { type: "sms", number: "9876543210" },
+        { type: "text", text: "Hello World" },
+        () => {
+          postMock.verify();
+          done();
+        }
+      );
+    });
+
+    it("uses basicAuth auth if option supplied", function(done) {
+      const postMock = this.sandbox.mock(this.httpClientStub);
+      postMock
+        .expects("post")
+        .once()
+        .withArgs(
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match.any,
+          false,
+          true
+        )
+        .yields(null, []);
+
+      this.channel.send(
+        { type: "sms", number: "1234567890" },
+        { type: "sms", number: "9876543210" },
+        { type: "text", text: "Hello World" },
+        () => {
+          postMock.verify();
+          done();
+        },
+        { useBasicAuth: true }
+      );
+    });
   });
 });

--- a/test/Dispatch-test.js
+++ b/test/Dispatch-test.js
@@ -1,6 +1,31 @@
 import Dispatch from "../lib/Dispatch";
 import { expect, sinon, TestUtils } from "./NexmoTestUtils";
 
+const workflow1 = {
+  to: { type: "viber_service_msg", number: "1234567890" },
+  from: { type: "viber_service_msg", number: "9876543210" },
+  message: {
+    content: {
+      type: "text",
+      text: "Hello World"
+    },
+    viber_service_msg: {
+      ttl: 60
+    }
+  }
+};
+
+const workflow2 = {
+  to: { type: "sms", number: "1234567890" },
+  from: { type: "sms", number: "9876543210" },
+  message: {
+    content: {
+      type: "text",
+      text: "Fallback to SMS from Viber"
+    }
+  }
+};
+
 describe("Dispatch", function() {
   beforeEach(function() {
     this.sandbox = sinon.sandbox.create();
@@ -39,30 +64,6 @@ describe("Dispatch", function() {
 
     it("formats the outgoing request correctly)", function(done) {
       const template = "failover";
-      const workflow1 = {
-        to: { type: "viber_service_msg", number: "1234567890" },
-        from: { type: "viber_service_msg", number: "9876543210" },
-        message: {
-          content: {
-            type: "text",
-            text: "Hello World"
-          },
-          viber_service_msg: {
-            ttl: 60
-          }
-        }
-      };
-
-      const workflow2 = {
-        to: { type: "sms", number: "1234567890" },
-        from: { type: "sms", number: "9876543210" },
-        message: {
-          content: {
-            type: "text",
-            text: "Fallback to SMS from Viber"
-          }
-        }
-      };
 
       const postMock = this.sandbox.mock(this.httpClientStub);
       postMock
@@ -78,6 +79,51 @@ describe("Dispatch", function() {
         postMock.verify();
         done();
       });
+    });
+
+    it("uses JWT auth by default", function(done) {
+      const postMock = this.sandbox.mock(this.httpClientStub);
+      postMock
+        .expects("post")
+        .once()
+        .withArgs(
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match.any,
+          true,
+          undefined
+        )
+        .yields(null, []);
+
+      this.dispatch.create("failover", [workflow1, workflow2], () => {
+        postMock.verify();
+        done();
+      });
+    });
+
+    it("uses basicAuth auth if option supplied", function(done) {
+      const postMock = this.sandbox.mock(this.httpClientStub);
+      postMock
+        .expects("post")
+        .once()
+        .withArgs(
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match.any,
+          false,
+          true
+        )
+        .yields(null, []);
+
+      this.dispatch.create(
+        "failover",
+        [workflow1, workflow2],
+        () => {
+          postMock.verify();
+          done();
+        },
+        { useBasicAuth: true }
+      );
     });
   });
 });


### PR DESCRIPTION
- Added extra param to Channel and Dispatch  opts = {useBasicAuth: true}
- Added param to HttpClient.post() to allow BasicAuth

Sample api usage:
```
const Nexmo = require('nexmo');

const nexmo = new Nexmo({
  apiKey: 'key,
  apiSecret: 'secret',
});

const message = {
  content: {
    type: 'text',
    text: 'Hello from Nexmo',
  },
};

nexmo.channel.send(
  { type: 'sms', number: '01234567890' },
  { type: 'sms', number: 'Nexmo' },
  message,
  (err, data) => { console.log(data.message_uuid); },
  {useBasicAuth: true}
);
```

The one problem with this solution is that if you want to use `util.promisify` to call the API using a promise wrapper it wont work as the last arg is not the callback. However i prefer this option rather than the alternatives:
- breaking everyone using the API by rearranging params
- having a `sendWithBasicAuth` method