### PR TITLE
Fix Number Insight  Advanced Async

### DIFF
--- a/src/NumberInsight.js
+++ b/src/NumberInsight.js
@@ -74,15 +74,10 @@ class NumberInsight {
     // remove 'level' as it's a library-only parameter
     delete options.level;
 
-    if (level === "advanced" || level === "advancedAsync") {
-      if (level === "advanced") {
-        console.warn(
-          'DEPRECATION WARNING: Number Insight Advanced with a level of "advanced" will be synchronous in v2.0+. Consider using the level "advancedAsync" to keep using the async option.'
-        );
-      }
-      this._nexmo.numberInsightAdvancedAsync.apply(this._nexmo, arguments);
-    } else if (level === "advancedSync") {
+    if (level === "advanced"){
       this._nexmo.numberInsightAdvanced.apply(this._nexmo, arguments);
+    } else if (level === "advancedAsync") {
+      this._nexmo.numberInsightAdvancedAsync.apply(this._nexmo, arguments);
     } else if (level === "standard") {
       this._nexmo.numberInsightStandard.apply(this._nexmo, arguments);
     } else {


### PR DESCRIPTION
The Async calls to number insight were not working as per the building blocks, they were making the Synchronous call and there was never a callback to the URL.
It looks as if the naming was mixed up betweeen Sync and Async.
This fixes that issue.
Also we were printing a console warn that in 2.0 advanced would move to being Syncronous, we're now way past that so I've removed the warning to cleanup that block of code.
