### PR TITLE
Add new numbers fields to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,8 @@ nexmo.number.get(options, callback);
   * `search_pattern`
   * `index`
   * `size`
+  * `has_application`
+  * `application_id`
 
 For more details about these options, refer to the [Numbers API reference](https://developer.nexmo.com/api/numbers#getOwnedNumbers)
 


### PR DESCRIPTION
We added two new fields to the Numbers API but I can use them with this library already since it simply passes the parameters through. Added them to the README for clarity and if there's an issue somewhere for adding `has_application` and `application_id` support to node: I've tested this and it works great :)