### PR TITLE
Remove logs from ResourceTestHelper.js

### DIFF
--- a/test/ResourceTestHelper.js
+++ b/test/ResourceTestHelper.js
@@ -34,8 +34,6 @@ class ResourceTestHelper {
         expected = params;
       }
 
-      console.log(expected, actual);
-
       // We strip api_key and api_secret out of `path` so that our tests
       // only look for specific parameters
       var qs = actual.path.split("?");


### PR DESCRIPTION
Remove extraneous console.log from the tests, it's creating chaotic output.