### PR TITLE
Add PSD2 Support for Verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.7.1
-- ADDED: Support for Verify PSD2 requestes via `nexmo.verify.psd2()`.
+## 2.8.0
+- ADDED: Support for Verify PSD2 requests via `nexmo.verify.psd2()`.
 
 ## 2.7.0
 - ADDED: Made `apiKey` and `apiSecret` optional when `applicationId` and `privateKey` are present in Nexmo constructor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.7.1
+- ADDED: Support for Verify PSD2 requestes via `nexmo.verify.psd2()`.
+
 ## 2.7.0
 - ADDED: Made `apiKey` and `apiSecret` optional when `applicationId` and `privateKey` are present in Nexmo constructor.
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ For more information check the documentation at https://developer.nexmo.com/api/
 ### Submit a PSD2 (Payment Services Directive 2) Verification Request
 
 ```js
-nexmo.verify.pd2({number:<NUMBER_TO_BE_VERIFIED>,payee:<NAME_OF_THE_SELLER>,amount:<AMOUNT_IN_EUROS>},callback);
+nexmo.verify.psd2({number:<NUMBER_TO_BE_VERIFIED>,payee:<NAME_OF_THE_SELLER>,amount:<AMOUNT_IN_EUROS>},callback);
 ```
 
 For more information check the documentation at https://developer.nexmo.com/api/verify#verifyRequestWithPSD2

--- a/README.md
+++ b/README.md
@@ -252,6 +252,14 @@ nexmo.verify.request({number:<NUMBER_TO_BE_VERIFIED>,brand:<NAME_OF_THE_APP>},ca
 
 For more information check the documentation at https://developer.nexmo.com/api/verify#verify-request
 
+### Submit a PSD2 (Payment Services Directive 2) Verification Request
+
+```js
+nexmo.verify.pd2({number:<NUMBER_TO_BE_VERIFIED>,payee:<NAME_OF_THE_SELLER>,amount:<AMOUNT_IN_EUROS>},callback);
+```
+
+For more information check the documentation at https://developer.nexmo.com/api/verify#verifyRequestWithPSD2
+
 ### Validate the response of a Verification Request
 
 ```js
@@ -825,6 +833,7 @@ nexmo.options.rest.postUseQueryString(
   * [ ] Advanced Async Webhook
 * Verify
   * [x] Verify
+  * [x] PSD2
   * [x] Check
   * [x] Search
   * [x] Control

--- a/examples/ex-send-psd2-verification-with-workflow.js
+++ b/examples/ex-send-psd2-verification-with-workflow.js
@@ -1,0 +1,18 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+    apiKey: config.API_KEY,
+    apiSecret: config.API_SECRET
+  }, {
+    debug: config.DEBUG
+  });
+
+  nexmo.verify.psd2({
+    number: config.TO_NUMBER,
+    payee: config.BRAND_NAME,
+    amount: "10",
+    workflow_id: config.WORKFLOW_ID
+  }, callback);
+};

--- a/examples/ex-send-psd2-verification.js
+++ b/examples/ex-send-psd2-verification.js
@@ -1,0 +1,17 @@
+module.exports = function(callback, config) {
+
+  var Nexmo = require('../lib/Nexmo');
+
+  var nexmo = new Nexmo({
+    apiKey: config.API_KEY,
+    apiSecret: config.API_SECRET
+  }, {
+    debug: config.DEBUG
+  });
+
+  nexmo.verify.psd2({
+    number: config.TO_NUMBER,
+    payee: config.BRAND_NAME,
+    amount: "10",
+  }, callback);
+};

--- a/examples/run-examples.js
+++ b/examples/run-examples.js
@@ -61,6 +61,8 @@ exampleFiles = [
   // 'ex-make-call-ncco.js',
   // 'ex-send-verification.js',
   // 'ex-send-verification-with-workflow.js',
+  // 'ex-send-psd2-verification.js',
+  // 'ex-send-psd2-verification-with-workflow.js',
   // 'ex-check-verification.js',
   // 'ex-control-verification.js',
   // 'ex-search-verification.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexmo",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1127,7 +1127,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -5597,7 +5598,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "micromatch": {
@@ -7101,7 +7103,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexmo",
   "author": "nexmo",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "main": "lib/Nexmo",
   "types": "./typings/index.d.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexmo",
   "author": "nexmo",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "lib/Nexmo",
   "types": "./typings/index.d.ts",
   "keywords": [

--- a/src/Verify.js
+++ b/src/Verify.js
@@ -57,6 +57,24 @@ class Verify {
   /**
    * TODO: document
    */
+  psd2(inputParams, callback) {
+    inputParams["api_key"] = this.creds.apiKey;
+    inputParams["api_secret"] = this.creds.apiSecret;
+    this.options.httpClient.request(
+      {
+        host: this.options.apiHost || "api.nexmo.com",
+        path: Utils.createPathWithQuery(
+          `${Verify.PATH.replace("{action}", "/psd2")}`,
+          inputParams
+        )
+      },
+      callback
+    );
+  }
+
+  /**
+   * TODO: document
+   */
   check(inputParams, callback) {
     if (!inputParams.request_id || !inputParams.code) {
       Utils.sendError(

--- a/test/Verify-test.js
+++ b/test/Verify-test.js
@@ -76,7 +76,26 @@ describe("Verify", () => {
     verify.request({ number: "123", brand: "acme" }, emptyCallback);
 
     expect(httpClientStub.request).to.have.been.calledWith(
-      sinon.match(ResourceTestHelper.requestArgsMatch({}))
+      sinon.match({
+        host: "api.nexmo.com",
+        path:
+          "/verify/json?number=123&brand=acme&api_key=some-key&api_secret=some-secret"
+      })
+    );
+  });
+
+  it("should allow sending a psd2verify request", () => {
+    verify.psd2(
+      { number: "123", payee: "acme", amount: "amount" },
+      emptyCallback
+    );
+
+    expect(httpClientStub.request).to.have.been.calledWith(
+      sinon.match({
+        host: "api.nexmo.com",
+        path:
+          "/verify/psd2/json?number=123&payee=acme&amount=amount&api_key=some-key&api_secret=some-secret"
+      })
     );
   });
 


### PR DESCRIPTION
This PR adds `nexmo.verify.psd2` as a method, and updates all the necessary files for release.

To run it:
- switch to the `psd2` branch
- `npm compile`
- uncomment the added examples in `run-examples.js`
- `node run-examples.js`

Note: you can't run both examples at the same time, Verify won't let you run concurrent verifications on the same number. So each at a time. If you don't want to wait 5 minutes and receive an SMS and 2 phone calls in the process, uncomment the `check-verify` example, and run it with the code you got from psd2.