### PR TITLE
Treat keys as strings by default

### DIFF
--- a/examples/ex-keyfile-creds.js
+++ b/examples/ex-keyfile-creds.js
@@ -1,0 +1,16 @@
+module.exports = function(callback, config) {
+  var Nexmo = require("../lib/Nexmo");
+
+  var nexmo = new Nexmo(
+    {
+      applicationId: config.APP_ID,
+      privateKey: config.PRIVATE_KEY
+    },
+    { debug: config.DEBUG }
+  );
+
+  if(!nexmo.credentials.privateKey) {
+    // no key found
+    throw new Error("PrivateKey not loaded");
+  }
+};

--- a/examples/run-examples.js
+++ b/examples/run-examples.js
@@ -53,6 +53,7 @@ function runExample(exampleFile, callback) {
 // By default all examples are run.
 // Use this array to run a select number of examples.
 exampleFiles = [
+  // 'ex-keyfile-creds.js',
   // 'ex-change-api-host.js',
   // 'ex-change-rest-host.js',
   // 'ex-check-balance.js',

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -39,16 +39,11 @@ class Credentials {
 
     if (privateKey instanceof Buffer) {
       this.privateKey = privateKey;
-    } else if (
-      typeof privateKey === "string" &&
-      privateKey.startsWith("-----BEGIN PRIVATE KEY-----")
-    ) {
-      this.privateKey = new Buffer(privateKey);
-    } else if (privateKey !== undefined) {
-      if (!fs.existsSync(privateKey)) {
-        throw new Error(`File "${privateKey}" not found.`);
-      }
-      this.privateKey = fs.readFileSync(privateKey);
+    } else if (typeof privateKey === "string") {
+      if (fs.existsSync(privateKey)) {
+        privateKey = fs.readFileSync(privateKey);
+      } 
+      this.privateKey = Buffer.from(privateKey.replace(/\\n/g, '\n').replace(/\n\s\s/g, '\n'), 'utf-8');     
     }
 
     /** @private */

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -38,12 +38,21 @@ class Credentials {
     this.signatureMethod = signatureMethod;
 
     if (privateKey instanceof Buffer) {
+      // it is already a buffer, use it as-is
       this.privateKey = privateKey;
     } else if (typeof privateKey === "string") {
+      // is this a filename that we can find?
       if (fs.existsSync(privateKey)) {
-        privateKey = fs.readFileSync(privateKey);
-      } 
-      this.privateKey = Buffer.from(privateKey.replace(/\\n/g, '\n').replace(/\n\s\s/g, '\n'), 'utf-8');     
+        // it is a file, use its contents
+        this.privateKey = fs.readFileSync(privateKey);
+      } else {
+        // a string but not a filename, does it look like a key?
+        if(privateKey.startsWith("-----BEGIN PRIVATE KEY-----")) {
+          // OK it's a key. Check for \n, replace with newlines
+          privateKey = privateKey.replace(/\\n/g, '\n');
+          this.privateKey = Buffer.from(privateKey, 'utf-8');
+        }
+      }
     }
 
     /** @private */


### PR DESCRIPTION
This change attempts to make supplying a private key more robust. It treats a supplied string as the key itself, instead of as the path to the key, by default. It also converts "\n" to an actual newline and trims the spaces from a "newline-space-space" pattern I kept finding in keys generated via the dashboard.