### PR TITLE
Fix typo in typings: `error-text`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -67,7 +67,7 @@ declare module 'vonage' {
 
     export interface MessageError {
         status: MessageRequestResponseStatusCode;
-        error_text: string;
+        'error-text': string;
     }
     
     export interface MessageRequestResponse {


### PR DESCRIPTION
There seems to be a typo in the typings. It doesn't match what I receive from the API.
`error_text-text` should be `error-text`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.