### PR TITLE
Remove QueryString Params from SMS Send methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.10.8
+
+- Move querystring params in SMS to the JSON body.
 
 ## 2.10.7
-* #429 Addressing typescript import bug
+
+- #429 Addressing typescript import bug
 
 ## 2.10.6
 
@@ -14,32 +18,32 @@ Updating main line branch tag. No changes.
 
 ### Fixed
 
-* #432 - Fix new issue with host override. 
+- #432 - Fix new issue with host override.
 
 ## 2.10.4
 
 ### Fixed
 
-* #400 - Fix issue with host override
+- #400 - Fix issue with host override
 
 ## 2.10.3
 
 ### Added
 
-* #400 - Added Yarn example in README.md
-* #380 - Added Number typings
-* #379 - Added Voice typings
-* #376 - Added Media typings
-* #373 - Added Number Insight typings
+- #400 - Added Yarn example in README.md
+- #380 - Added Number typings
+- #379 - Added Voice typings
+- #376 - Added Media typings
+- #373 - Added Number Insight typings
 
 ### Updated
 
-* #389 - Discriminating unions support for different message responses
-* #387 - Bump @babel/register from 7.11.5 to 7.12.0
-* #385 - Bump @babel/core from 7.11.6 to 7.12.0
-* #384 - Bump @babel/preset-env from 7.11.5 to 7.12.0
-* #378 - Allow for Full URL Overrides in Constructor
-* #375 - Updated uuid-dependency for performance improvement
+- #389 - Discriminating unions support for different message responses
+- #387 - Bump @babel/register from 7.11.5 to 7.12.0
+- #385 - Bump @babel/core from 7.11.6 to 7.12.0
+- #384 - Bump @babel/preset-env from 7.11.5 to 7.12.0
+- #378 - Allow for Full URL Overrides in Constructor
+- #375 - Updated uuid-dependency for performance improvement
 
 ### Fixed
 
@@ -47,132 +51,132 @@ Updating main line branch tag. No changes.
 
 ### Updated
 
-* #350 - Bump eslint-config-prettier from 6.11.0 to 6.12.0
+- #350 - Bump eslint-config-prettier from 6.11.0 to 6.12.0
 
 ### Fixed
 
-* #370 - Fixed typos
-* #369 - Fixed typos
-* #358 - Fixed typos
-* #357 - Fixed typos
-* #355 - Fixed types module name
-* #352 - Fixed typos
+- #370 - Fixed typos
+- #369 - Fixed typos
+- #358 - Fixed typos
+- #357 - Fixed typos
+- #355 - Fixed types module name
+- #352 - Fixed typos
 
 ## 2.10.1
 
 ### Updated
 
-* #347 - Correct license information
+- #347 - Correct license information
 
 ## 2.10.0
 
->This version serves as the change from the Nexmo namespace to the Vonage namespace. The module now resides on NPM as `@vonage/server-sdk`. Prior versions under the Nexmo namespace will remain in maintenance mode for the next 12 months and recieve bug and security fixes. All new functionality will only be added to the @vonage namespace.
+> This version serves as the change from the Nexmo namespace to the Vonage namespace. The module now resides on NPM as `@vonage/server-sdk`. Prior versions under the Nexmo namespace will remain in maintenance mode for the next 12 months and recieve bug and security fixes. All new functionality will only be added to the @vonage namespace.
 
 ### Updated
 
-* #321 - Bump jsonwebtoken from 8.4.0 to 8.5.1
-* #322 - Bump body-parser from 1.18.3 to 1.19.0
-* #324 - Bump cross-env from 5.2.0 to 7.0.2
-* #325 - **Migrated SDK module from `nexmo` to `@vonage/server-sdk`**
-* #326 - Bump bluebird from 3.5.3 to 3.7.2
-* #327 - Bump @babel/plugin-proposal-object-rest-spread from 7.10.4 to 7.11.0
-* #328 - Bump @babel/register from 7.10.5 to 7.11.5
-* #329 - Bump @babel/core from 7.11.5 to 7.11.6
-* #330 - Bump @babel/preset-env from 7.10.4 to 7.11.5
-* #333 - Bump nyc from 14.1.1 to 15.1.0
-* #334 - Bump eslint-config-prettier from 6.2.0 to 6.11.0
-* #336 - Bump @babel/cli from 7.10.5 to 7.11.6
-* #339 - Bump dotenv from 2.0.0 to 8.2.0
-* #340 - Bump babel-plugin-istanbul from 4.1.6 to 6.0.0
-* #343 - Bump babel-plugin-add-module-exports from 1.0.2 to 1.0.4
-* #344 - Bump request from 2.88.0 to 2.88.2
+- #321 - Bump jsonwebtoken from 8.4.0 to 8.5.1
+- #322 - Bump body-parser from 1.18.3 to 1.19.0
+- #324 - Bump cross-env from 5.2.0 to 7.0.2
+- #325 - **Migrated SDK module from `nexmo` to `@vonage/server-sdk`**
+- #326 - Bump bluebird from 3.5.3 to 3.7.2
+- #327 - Bump @babel/plugin-proposal-object-rest-spread from 7.10.4 to 7.11.0
+- #328 - Bump @babel/register from 7.10.5 to 7.11.5
+- #329 - Bump @babel/core from 7.11.5 to 7.11.6
+- #330 - Bump @babel/preset-env from 7.10.4 to 7.11.5
+- #333 - Bump nyc from 14.1.1 to 15.1.0
+- #334 - Bump eslint-config-prettier from 6.2.0 to 6.11.0
+- #336 - Bump @babel/cli from 7.10.5 to 7.11.6
+- #339 - Bump dotenv from 2.0.0 to 8.2.0
+- #340 - Bump babel-plugin-istanbul from 4.1.6 to 6.0.0
+- #343 - Bump babel-plugin-add-module-exports from 1.0.2 to 1.0.4
+- #344 - Bump request from 2.88.0 to 2.88.2
 
 ## 2.9.1
 
-* FIXED: #317 - TypeError: Nexmo is not a constructor
+- FIXED: #317 - TypeError: Nexmo is not a constructor
 
 ## 2.9.0
 
-* FIXED: #295 - Nexmo constructor changes of given options object
-* ADDED: Optional `target_api_key` parameter for the `number.buy()` and `number.cancel()` methods.  
-* ADDED: Typings for Messages API
-* UPDATED: Private Key strings now replaces `\n` with newlines for easier usage in environment variables.
+- FIXED: #295 - Nexmo constructor changes of given options object
+- ADDED: Optional `target_api_key` parameter for the `number.buy()` and `number.cancel()` methods.
+- ADDED: Typings for Messages API
+- UPDATED: Private Key strings now replaces `\n` with newlines for easier usage in environment variables.
 
 ## 2.8.0
 
-* ADDED: Support for Verify PSD2 requests via `nexmo.verify.psd2()`.
+- ADDED: Support for Verify PSD2 requests via `nexmo.verify.psd2()`.
 
 ## 2.7.0
 
-* ADDED: Made `apiKey` and `apiSecret` optional when `applicationId` and `privateKey` are present in Nexmo constructor.
+- ADDED: Made `apiKey` and `apiSecret` optional when `applicationId` and `privateKey` are present in Nexmo constructor.
 
 ## 2.6.0
 
-* ADDED: Change host via the config object, using `apiHost` & `restHost`
+- ADDED: Change host via the config object, using `apiHost` & `restHost`
 
 ## 2.5.3
 
-* FIXED: URI Encode Signed SMS Message
+- FIXED: URI Encode Signed SMS Message
 
 ## 2.5.2
 
-* ADDED: Pricing API support
+- ADDED: Pricing API support
 
 ## 2.5.1
 
-* ADDED: typings for Verify API
-* ADDED: Applications API V2 support
+- ADDED: typings for Verify API
+- ADDED: Applications API V2 support
 
 ## 2.4.2
 
-* Added message signing for for sending SMS
-* Added `Nexmo.generateSignature` to verify signed messages
+- Added message signing for for sending SMS
+- Added `Nexmo.generateSignature` to verify signed messages
 
 ## 2.0.1
 
-* FIXED: #116 - default setting of `retry-after` for 429 http status code responses
+- FIXED: #116 - default setting of `retry-after` for 429 http status code responses
 
 ## 2.0.0
 
-* FIXED: #110 - check the `statusCode` on the response
-* FIXED: #114 - handle 429 HTTP status codes
-* UPDATED: To allow errors to be programmatically useful the `error` callback objects has been updated to `{statusCode: STATUS_CODE, body: JSON_BODY, headers: HEADERS}`
+- FIXED: #110 - check the `statusCode` on the response
+- FIXED: #114 - handle 429 HTTP status codes
+- UPDATED: To allow errors to be programmatically useful the `error` callback objects has been updated to `{statusCode: STATUS_CODE, body: JSON_BODY, headers: HEADERS}`
 
 ## 1.2.0
 
-* ADDED: Add File API to library. `nexmo.files.get` and `nexmo.files.save`.
+- ADDED: Add File API to library. `nexmo.files.get` and `nexmo.files.save`.
 
 ## 1.1.2
 
-* Fixed: Bug #104 - Fix JSON parsing error
+- Fixed: Bug #104 - Fix JSON parsing error
 
 ## 1.1.1
 
-* UPDATED: Changed User Agent format to match other libraries
-* FIXED: Bug #88 - Undefined method when missing `method` declaration
+- UPDATED: Changed User Agent format to match other libraries
+- FIXED: Bug #88 - Undefined method when missing `method` declaration
 
 ## 1.1.0
 
-* ADDED: `nexmo.generateJwt` to generate JWT based on instance credentials
-* ADDED: `Nexmo.generateJwt` static function to generate JWT
+- ADDED: `nexmo.generateJwt` to generate JWT based on instance credentials
+- ADDED: `Nexmo.generateJwt` static function to generate JWT
 
 ## [1.0.0]
 
-* ADDED: `applicationId` and `privateKey` properties to first constructor parameter to support JWT generation.
-* ADDED: `options.logger` to constructor 2nd parameter to allow adding customer logger.
-* ADDED: `options.appendToUserAgent` to constructor 2nd paramater to append custom string to `User-Agent` header sent to Nexmo.
-* ADDED: nexmo.calls adding support to `create`, `get`, `update` and `delete` calls.
-* ADDED: nexmo.applications adding support to `create`, `get`, `update` and `delete` calls.
-* ADDED: Functionality is now namespaced:
-    * `nexmo.message`
-    * `nexmo.calls`
-    * `nexmo.number`
-    * `nexmo.verify`
-    * `nexmo.numberInsight`
-    * `nexmo.account`
-    * `nexmo.voice` - legacy voice functionality
-* CHANGED: `var Nexmo = require('nexmo');` returns a class definition which should be created using the `new` operator e.g. `var nexmo = new Nexmo(args...);`.
-* REMOVED: `var nexmo = require('nexmo');` no longer exposes singleton functions offered by "easynexmo".
+- ADDED: `applicationId` and `privateKey` properties to first constructor parameter to support JWT generation.
+- ADDED: `options.logger` to constructor 2nd parameter to allow adding customer logger.
+- ADDED: `options.appendToUserAgent` to constructor 2nd paramater to append custom string to `User-Agent` header sent to Nexmo.
+- ADDED: nexmo.calls adding support to `create`, `get`, `update` and `delete` calls.
+- ADDED: nexmo.applications adding support to `create`, `get`, `update` and `delete` calls.
+- ADDED: Functionality is now namespaced:
+  - `nexmo.message`
+  - `nexmo.calls`
+  - `nexmo.number`
+  - `nexmo.verify`
+  - `nexmo.numberInsight`
+  - `nexmo.account`
+  - `nexmo.voice` - legacy voice functionality
+- CHANGED: `var Nexmo = require('nexmo');` returns a class definition which should be created using the `new` operator e.g. `var nexmo = new Nexmo(args...);`.
+- REMOVED: `var nexmo = require('nexmo');` no longer exposes singleton functions offered by "easynexmo".
 
 ## Pre 1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vonage/server-sdk",
   "author": "vonage",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "main": "lib/Vonage",
   "types": "./typings/index.d.ts",
   "keywords": [

--- a/src/HttpClient.js
+++ b/src/HttpClient.js
@@ -51,18 +51,12 @@ class HttpClient {
       endpoint.method = method;
     }
 
-    if (endpoint.method === "POST" || endpoint.method === "DELETE") {
-      // TODO: verify the following fix is required
-      // Fix broken due ot 411 Content-Length error now sent by Vonage API
-      // PL 2016-Sept-6 - commented out Content-Length 0
-      // headers['Content-Length'] = 0;
-    }
     var options = {
       host: endpoint.host ? endpoint.host : this.host,
       port: this.port,
       path: endpoint.path,
       method: endpoint.method,
-      headers: Object.assign({}, this.headers),
+      headers: Object.assign({}, this.headers, endpoint.headers),
     };
 
     if (this.timeout !== undefined) {
@@ -110,6 +104,7 @@ class HttpClient {
     }
 
     this.logger.info("Request:", options, "\nBody:", endpoint.body);
+
     var request;
 
     if (options.port === 443) {

--- a/src/Message.js
+++ b/src/Message.js
@@ -40,55 +40,62 @@ class Message {
     this.shortcodeMarketing = _shortcode.shortcodeMarketing.bind(_shortcode);
   }
 
-  _sendRequest(endpoint, method, callback) {
-    endpoint.path =
-      endpoint.path +
-      (endpoint.path.indexOf("?") > 0 ? "&" : "?") +
-      querystring.stringify({
-        api_key: this.creds.apiKey,
-        api_secret: this.creds.apiSecret,
-      });
-    this.options.httpClient.request(endpoint, method, callback);
-  }
-
-  _sendMessage(data, callback) {
+  _checkToAndFrom(data) {
     if (!data.from) {
       Utils.sendError(callback, new Error(Message.ERROR_MESSAGES.sender));
     } else if (!data.to) {
       Utils.sendError(callback, new Error(Message.ERROR_MESSAGES.to));
     } else {
-      var path = Message.PATH + "?" + querystring.stringify(data);
-      this.options.logger.info(
-        "sending message from " +
-          data.from +
-          " to " +
-          data.to +
-          " with message " +
-          data.text
-      );
-      this._sendRequest(
-        {
-          host: this.options.restHost || "rest.nexmo.com",
-          path: path,
-        },
-        "POST",
-        function (err, apiResponse) {
-          if (
-            !err &&
-            apiResponse.status &&
-            apiResponse.messages[0].status > 0
-          ) {
-            Utils.sendError(
-              callback,
-              new Error(apiResponse.messages[0]["error-text"]),
-              apiResponse
-            );
-          } else {
-            if (callback) callback(err, apiResponse);
-          }
-        }
-      );
+      return;
     }
+  }
+
+  // _sendMessageCallback
+
+  _sendMessage(data, callback) {
+    this._checkToAndFrom(data);
+
+    this.options.logger.info(
+      "sending message from " +
+        data.from +
+        " to " +
+        data.to +
+        " with message " +
+        data.text
+    );
+
+    let creds = {
+      api_key: this.creds.apiKey,
+      api_secret: this.creds.apiSecret,
+    };
+
+    let body = Object.assign({}, creds, data);
+    console.log({
+      host: this.options.restHost || "rest.nexmo.com",
+      path: Message.PATH,
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+    this.options.httpClient.request(
+      {
+        host: this.options.restHost || "rest.nexmo.com",
+        path: Message.PATH,
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      },
+      "POST",
+      (err, apiResponse) => {
+        if (!err && apiResponse.status && apiResponse.messages[0].status > 0) {
+          Utils.sendError(
+            callback,
+            new Error(apiResponse.messages[0]["error-text"]),
+            apiResponse
+          );
+        } else {
+          if (callback) callback(err, apiResponse);
+        }
+      }
+    );
   }
 
   /**

--- a/test/Message-test.js
+++ b/test/Message-test.js
@@ -115,8 +115,10 @@ describe("SMS", () => {
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match({
         host: "rest.nexmo.com",
-        path:
-          "/sms/json?from=1234&to=1234&text=test&api_key=some-key&api_secret=some-secret",
+        path: "/sms/json",
+        body:
+          '{"api_key":"some-key","api_secret":"some-secret","from":"1234","to":"1234","text":"test"}',
+        headers: { "Content-Type": "application/json" },
       }),
       "POST"
     );
@@ -137,8 +139,10 @@ describe("SMS", () => {
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match({
         host: "rest.example.com",
-        path:
-          "/sms/json?from=1234&to=1234&text=test&api_key=some-key&api_secret=some-secret",
+        path: "/sms/json",
+        body:
+          '{"api_key":"some-key","api_secret":"some-secret","from":"1234","to":"1234","text":"test"}',
+        headers: { "Content-Type": "application/json" },
       }),
       "POST"
     );
@@ -150,8 +154,10 @@ describe("SMS", () => {
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match({
         host: "rest.nexmo.com",
-        path:
-          "/sms/json?from=1234&to=1234&type=binary&body=00&udh=ff&api_key=some-key&api_secret=some-secret",
+        path: "/sms/json",
+        body:
+          '{"api_key":"some-key","api_secret":"some-secret","from":"1234","to":"1234","type":"binary","body":"00","udh":"ff"}',
+        headers: { "Content-Type": "application/json" },
       }),
       "POST"
     );
@@ -172,8 +178,10 @@ describe("SMS", () => {
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match({
         host: "rest.example.com",
-        path:
-          "/sms/json?from=1234&to=1234&type=binary&body=00&udh=ff&api_key=some-key&api_secret=some-secret",
+        path: "/sms/json",
+        body:
+          '{"api_key":"some-key","api_secret":"some-secret","from":"1234","to":"1234","type":"binary","body":"00","udh":"ff"}',
+        headers: { "Content-Type": "application/json" },
       }),
       "POST"
     );
@@ -193,8 +201,10 @@ describe("SMS", () => {
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match({
         host: "rest.nexmo.com",
-        path:
-          "/sms/json?from=1234&to=1234&type=wappush&title=title&validity=validity&url=url&api_key=some-key&api_secret=some-secret",
+        path: "/sms/json",
+        body:
+          '{"api_key":"some-key","api_secret":"some-secret","from":"1234","to":"1234","type":"wappush","title":"title","validity":"validity","url":"url"}',
+        headers: { "Content-Type": "application/json" },
       }),
       "POST"
     );
@@ -223,8 +233,10 @@ describe("SMS", () => {
     expect(httpClientStub.request).to.have.been.calledWith(
       sinon.match({
         host: "rest.example.com",
-        path:
-          "/sms/json?from=1234&to=1234&type=wappush&title=title&validity=validity&url=url&api_key=some-key&api_secret=some-secret",
+        path: "/sms/json",
+        body:
+          '{"api_key":"some-key","api_secret":"some-secret","from":"1234","to":"1234","type":"wappush","title":"title","validity":"validity","url":"url"}',
+        headers: { "Content-Type": "application/json" },
       }),
       "POST"
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current SMS methods send potentially private data in query string parameters. This changes the payload to be sent via json body. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is solving an escalated issue -> https://jira.vonage.com/browse/DEVX-5516

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I changed the match from the URL with query params, to include a body and custom header. 
## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.