### PR TITLE
If requested file response is not a buffer, turn into a string

### DIFF
--- a/src/FilesResource.js
+++ b/src/FilesResource.js
@@ -65,6 +65,10 @@ class FilesResource {
   }
 
   __storeFile(data, file, callback) {
+    if (!Buffer.isBuffer(data)) {
+      data = JSON.stringify(data);
+    }
+
     fs.writeFile(file, data, (error) => {
       if (error) {
         callback(error, null);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Converts JSON objects to a string before trying to save to a file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
VAPI now supports transcription files as a developer preview option, but the current download function through the SDK assumes that the requested file is a Buffer (or at least something that can be directly written to a file). Because the transcription API returns a JSON response instead of a file, it gets converted to an object. This turns the object back into a string before we try and save it.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested trying to download transcription files.

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.