### PR TITLE
build: cleanup TS build files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12237,26 +12237,18 @@
     },
     "packages/accounts": {
       "name": "@vonage/accounts",
-      "version": "0.2.1",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
-      }
-    },
-    "packages/accounts/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
+        "@vonage/server-client": "^0.4.1"
       }
     },
     "packages/applications": {
       "name": "@vonage/applications",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
+        "@vonage/server-client": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12267,14 +12259,6 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      }
-    },
-    "packages/applications/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
       }
     },
     "packages/auth": {
@@ -12314,10 +12298,10 @@
     },
     "packages/messages": {
       "name": "@vonage/messages",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
+        "@vonage/server-client": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^28.1",
@@ -12332,36 +12316,20 @@
         "typescript": "^4.7.4"
       }
     },
-    "packages/messages/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
-      }
-    },
     "packages/number-insights": {
       "name": "@vonage/number-insights",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
-      }
-    },
-    "packages/number-insights/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
+        "@vonage/server-client": "^0.4.1"
       }
     },
     "packages/numbers": {
       "name": "@vonage/numbers",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
+        "@vonage/server-client": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12373,33 +12341,17 @@
         "typescript": "^4.7.4"
       }
     },
-    "packages/numbers/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
-      }
-    },
     "packages/pricing": {
       "name": "@vonage/pricing",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
-      }
-    },
-    "packages/pricing/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
+        "@vonage/server-client": "^0.4.1"
       }
     },
     "packages/server-client": {
       "name": "@vonage/server-client",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@vonage/auth": "^0.6.0",
@@ -12409,35 +12361,27 @@
     },
     "packages/server-sdk": {
       "name": "@vonage/server-sdk",
-      "version": "3.0.0-alpha.1",
+      "version": "3.0.0-alpha.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/accounts": "^0.2.1",
-        "@vonage/applications": "^0.3.1",
-        "@vonage/messages": "^0.2.1",
-        "@vonage/number-insights": "^0.2.1",
-        "@vonage/numbers": "^0.2.1",
-        "@vonage/pricing": "^0.2.1",
-        "@vonage/server-client": "^0.4.0",
-        "@vonage/sms": "^0.3.1",
-        "@vonage/verify": "^0.2.1",
-        "@vonage/voice": "^0.2.1"
-      }
-    },
-    "packages/server-sdk/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
+        "@vonage/accounts": "^0.2.4",
+        "@vonage/applications": "^0.3.3",
+        "@vonage/messages": "^0.2.3",
+        "@vonage/number-insights": "^0.2.3",
+        "@vonage/numbers": "^0.2.3",
+        "@vonage/pricing": "^0.2.3",
+        "@vonage/server-client": "^0.4.1",
+        "@vonage/sms": "^0.3.3",
+        "@vonage/verify": "^0.2.3",
+        "@vonage/voice": "^0.2.3"
       }
     },
     "packages/sms": {
       "name": "@vonage/sms",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
+        "@vonage/server-client": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12447,22 +12391,14 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      }
-    },
-    "packages/sms/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
       }
     },
     "packages/verify": {
       "name": "@vonage/verify",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
+        "@vonage/server-client": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12472,14 +12408,6 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      }
-    },
-    "packages/verify/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
       }
     },
     "packages/vetch": {
@@ -12500,10 +12428,10 @@
     },
     "packages/video": {
       "name": "@vonage/video",
-      "version": "0.8.1",
+      "version": "0.8.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
+        "@vonage/server-client": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12516,20 +12444,12 @@
         "typescript": "^4.7.4"
       }
     },
-    "packages/video/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
-      }
-    },
     "packages/voice": {
       "name": "@vonage/voice",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.0"
+        "@vonage/server-client": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12539,14 +12459,6 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      }
-    },
-    "packages/voice/node_modules/@vonage/auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-      "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-      "dependencies": {
-        "@vonage/jwt": "^0.3.0"
       }
     }
   },
@@ -15061,23 +14973,14 @@
     "@vonage/accounts": {
       "version": "file:packages/accounts",
       "requires": {
-        "@vonage/server-client": "^0.4.0"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
+        "@vonage/server-client": "^0.4.1"
       }
     },
     "@vonage/applications": {
       "version": "file:packages/applications",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.0",
+        "@vonage/server-client": "^0.4.1",
         "jsonwebtoken": "^8.5.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
@@ -15085,15 +14988,6 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
       }
     },
     "@vonage/auth": {
@@ -15127,7 +15021,7 @@
       "version": "file:packages/messages",
       "requires": {
         "@types/jest": "^28.1",
-        "@vonage/server-client": "^0.4.0",
+        "@vonage/server-client": "^0.4.1",
         "jest": "^28.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
@@ -15137,67 +15031,31 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
       }
     },
     "@vonage/number-insights": {
       "version": "file:packages/number-insights",
       "requires": {
-        "@vonage/server-client": "^0.4.0"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
+        "@vonage/server-client": "^0.4.1"
       }
     },
     "@vonage/numbers": {
       "version": "file:packages/numbers",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.0",
+        "@vonage/server-client": "^0.4.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
       }
     },
     "@vonage/pricing": {
       "version": "file:packages/pricing",
       "requires": {
-        "@vonage/server-client": "^0.4.0"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
+        "@vonage/server-client": "^0.4.1"
       }
     },
     "@vonage/server-client": {
@@ -15211,69 +15069,42 @@
     "@vonage/server-sdk": {
       "version": "file:packages/server-sdk",
       "requires": {
-        "@vonage/accounts": "^0.2.1",
-        "@vonage/applications": "^0.3.1",
-        "@vonage/messages": "^0.2.1",
-        "@vonage/number-insights": "^0.2.1",
-        "@vonage/numbers": "^0.2.1",
-        "@vonage/pricing": "^0.2.1",
-        "@vonage/server-client": "^0.4.0",
-        "@vonage/sms": "^0.3.1",
-        "@vonage/verify": "^0.2.1",
-        "@vonage/voice": "^0.2.1"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
+        "@vonage/accounts": "^0.2.4",
+        "@vonage/applications": "^0.3.3",
+        "@vonage/messages": "^0.2.3",
+        "@vonage/number-insights": "^0.2.3",
+        "@vonage/numbers": "^0.2.3",
+        "@vonage/pricing": "^0.2.3",
+        "@vonage/server-client": "^0.4.1",
+        "@vonage/sms": "^0.3.3",
+        "@vonage/verify": "^0.2.3",
+        "@vonage/voice": "^0.2.3"
       }
     },
     "@vonage/sms": {
       "version": "file:packages/sms",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.0",
+        "@vonage/server-client": "^0.4.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
       }
     },
     "@vonage/verify": {
       "version": "file:packages/verify",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.0",
+        "@vonage/server-client": "^0.4.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
       }
     },
     "@vonage/vetch": {
@@ -15292,7 +15123,7 @@
       "version": "file:packages/video",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.0",
+        "@vonage/server-client": "^0.4.1",
         "jsonwebtoken": "^8.5.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
@@ -15300,37 +15131,19 @@
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
       }
     },
     "@vonage/voice": {
       "version": "file:packages/voice",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.0",
+        "@vonage/server-client": "^0.4.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^4.7.4"
-      },
-      "dependencies": {
-        "@vonage/auth": {
-          "version": "https://registry.npmjs.org/@vonage/auth/-/auth-0.5.0.tgz",
-          "integrity": "sha512-Q3VN1TuYg6LfE3M/XhdF1cHYNRvCipJHWApWycVNpSoKujfe7YHXJHDuGHwdIIa8OfQsOEgnEg7//V14zlHNnA==",
-          "requires": {
-            "@vonage/jwt": "^0.3.0"
-          }
-        }
       }
     },
     "@webassemblyjs/ast": {

--- a/packages/accounts/tsconfig.build.json
+++ b/packages/accounts/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/accounts/tsconfig.json
+++ b/packages/accounts/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/applications/tsconfig.build.json
+++ b/packages/applications/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/applications/tsconfig.json
+++ b/packages/applications/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/auth/tsconfig.build.json
+++ b/packages/auth/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,14 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/jwt/lib/acl.ts
+++ b/packages/jwt/lib/acl.ts
@@ -1,1 +1,0 @@
-import { JWT } from '.'

--- a/packages/jwt/tsconfig.build.json
+++ b/packages/jwt/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/jwt/tsconfig.json
+++ b/packages/jwt/tsconfig.json
@@ -1,14 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/messages/lib/classes/Viber/Image.ts
+++ b/packages/messages/lib/classes/Viber/Image.ts
@@ -1,5 +1,4 @@
 import { ImageObject } from '../../interfaces/ImageObject'
-import { MessageType } from '../../interfaces/Messenger/MessageType'
 import { MessageConfig } from '../../interfaces/Viber/MessageConfig'
 import { AbstractImageMessage } from '../AbstractImageMessage'
 

--- a/packages/messages/tsconfig.build.json
+++ b/packages/messages/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/messages/tsconfig.json
+++ b/packages/messages/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/number-insights/tsconfig.build.json
+++ b/packages/number-insights/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/number-insights/tsconfig.json
+++ b/packages/number-insights/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/numbers/tsconfig.build.json
+++ b/packages/numbers/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/numbers/tsconfig.json
+++ b/packages/numbers/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/pricing/tsconfig.build.json
+++ b/packages/pricing/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/pricing/tsconfig.json
+++ b/packages/pricing/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/server-client/tsconfig.build.json
+++ b/packages/server-client/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/server-client/tsconfig.json
+++ b/packages/server-client/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/server-sdk/tsconfig.build.json
+++ b/packages/server-sdk/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/server-sdk/tsconfig.json
+++ b/packages/server-sdk/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/sms/lib/classes/Error/MessageSendAllFailure.ts
+++ b/packages/sms/lib/classes/Error/MessageSendAllFailure.ts
@@ -1,4 +1,4 @@
-import { Message, SendSMSResponse } from '../../types'
+import { SendSMSResponse } from '../../types'
 
 export class MessageSendAllFailure extends Error {
     protected response: SendSMSResponse

--- a/packages/sms/lib/types.ts
+++ b/packages/sms/lib/types.ts
@@ -1,5 +1,5 @@
 import { AuthOpts, AuthInterface } from '@vonage/auth'
-import { VetchError, VetchResponse, VetchOptions } from '@vonage/vetch'
+import { VetchResponse, VetchOptions } from '@vonage/vetch'
 
 export type SMSClassParameters = AuthOpts &
     VetchOptions & {

--- a/packages/sms/tsconfig.build.json
+++ b/packages/sms/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/sms/tsconfig.json
+++ b/packages/sms/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/verify/tsconfig.build.json
+++ b/packages/verify/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/verify/tsconfig.json
+++ b/packages/verify/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/vetch/tsconfig.build.json
+++ b/packages/vetch/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/vetch/tsconfig.json
+++ b/packages/vetch/tsconfig.json
@@ -1,14 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/video/tsconfig.build.json
+++ b/packages/video/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/video/tsconfig.json
+++ b/packages/video/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/voice/lib/classes/NCCO/NCCOBuilder.ts
+++ b/packages/voice/lib/classes/NCCO/NCCOBuilder.ts
@@ -1,6 +1,5 @@
 import { isNCCOSerializable } from '../../interfaces/NCCO/Serializable'
 import { Action } from '../../ncco'
-import { Serializable } from '../../ncco'
 
 export class NCCOBuilder {
     protected actions = []

--- a/packages/voice/tsconfig.build.json
+++ b/packages/voice/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "declaration": true,
+        "importHelpers": true,
+        "noUnusedLocals": true,
+        "pretty": true,
+        "strict": false,
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true
+    },
+    "exclude": [
+        "dist",
+        "node_modules",
+        "**/*.test.*"
+    ],
+    "ts-node": {
+        "compilerOptions": {
+            "module": "commonjs"
+        }
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,11 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "sourceMap": true,
-      "noImplicitReturns": true,
-      "noUnusedLocals": true,
-      "strict": false,
-      "esModuleInterop": true,
-      "target": "es6",
-      "moduleResolution": "node",
-      "module": "CommonJS",
-      "types": ["node", "jest"],
-      "baseUrl": "../"
-  }
+    "extends": "./tsconfig.build.json",
+
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@vonage/*": ["packages/*/lib"]
+        },
+        "noEmit": true
+    }
 }


### PR DESCRIPTION
Cleaning up Typescript build files 

## Description
Having multiple `tsconfig.json` files makes it difficult to manage the build process. Having one central config file for all the packages helps reduce DRY config options while still allowing finer control over the build process. There are two different files used to allow separation from building and testing. 

## Motivation and Context
Reduces DRY configs and makes building typescript more manageable 

## Testing Details
Run `tsc --build --verbose` and confirm that all typescript files built without errors

## Example Output or Screenshots (if appropriate)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.