### PR TITLE
build: cleanup TS build files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node }}
+
     - name: Install dependencies
       run: npx lerna bootstrap
+
     - name: Lint, Compile, Test
       run: npx lerna run compile && npm run test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+save-exact=true
+bin-links=true
+engine-strict=true

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,3 @@
-// Copyright 2020 Vonage
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 const base = require('./jest.config.base.js')
 
 module.exports = {
@@ -17,47 +5,3 @@ module.exports = {
     projects: ['<rootDir>/packages/*/jest.config.js'],
     coverageDirectory: '<rootDir>/coverage/',
 }
-// module.exports = {
-//     transform: { '^.+\\.(ts)?$': 'ts-jest' },
-//     testEnvironment: 'node',
-//     testPathIgnorePatterns: ['.d.ts', '.js'],
-//     testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.ts?$',
-//   moduleFileExtensions: ['ts', 'js'],
-//     collectCoverageFrom: [`**/packages/.*/lib/*.ts`],
-//     modulePathIgnorePatterns: [
-//         'src/.*',
-//         '/test/.*',
-//         '/typings/.*',
-//         'packages/.*/dist',
-//     ],
-// }
-// module.exports = {
-//     preset: 'ts-jest',
-//     testEnvironment: 'node',
-//     collectCoverageFrom: [`**/packages/*/**/*.ts`],
-//     modulePathIgnorePatterns: [
-//         'src/.*',
-//         '/test/.*',
-//         '/typings/.*',
-//         'packages/.*/build',
-//     ],
-//     coverageThreshold: {
-//         global: {
-//             branches: 80,
-//             functions: 80,
-//             lines: 80,
-//             statements: 80,
-//         },
-//     },
-//     projects: ['<rootDir>', '<rootDir>/packages/*/'],
-//     testPathIgnorePatterns: [
-//         '<rootDir>.*(node_modules)(?!.*@vonage.*).*$',
-//         '/src/',
-//         '/test/',
-//         '/typings/',
-//         '\\.snap$',
-//         '/packages/.*/build',
-//     ],
-//     testMatch: ['**/__test__/**/*.test.+(ts)'],
-//     watchPathIgnorePatterns: ['coverage'],
-// }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/jsonwebtoken": "^8.5.8"
       },
       "devDependencies": {
-        "@types/jest": "^28.1.6",
+        "@types/jest": "28.1.8",
         "@types/lodash.merge": "^4.6.7",
         "@types/node": "^18.6.4",
         "@types/node-fetch": "^2.6.2",
@@ -2793,9 +2793,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-      "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2855,12 +2855,12 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "28.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-      "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+      "version": "28.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "dependencies": {
-        "jest-matcher-utils": "^28.0.0",
+        "expect": "^28.0.0",
         "pretty-format": "^28.0.0"
       }
     },
@@ -10930,9 +10930,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -10949,17 +10949,17 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "terser": "^5.14.1"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -11221,9 +11221,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
-      "integrity": "sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.1.tgz",
+      "integrity": "sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -12237,18 +12237,18 @@
     },
     "packages/accounts": {
       "name": "@vonage/accounts",
-      "version": "0.2.4",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       }
     },
     "packages/applications": {
       "name": "@vonage/applications",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12298,10 +12298,10 @@
     },
     "packages/messages": {
       "name": "@vonage/messages",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1",
@@ -12318,18 +12318,18 @@
     },
     "packages/number-insights": {
       "name": "@vonage/number-insights",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       }
     },
     "packages/numbers": {
       "name": "@vonage/numbers",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12343,45 +12343,45 @@
     },
     "packages/pricing": {
       "name": "@vonage/pricing",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       }
     },
     "packages/server-client": {
       "name": "@vonage/server-client",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@vonage/auth": "^0.6.0",
         "@vonage/jwt": "^0.3.0",
-        "@vonage/vetch": "^0.2.0"
+        "@vonage/vetch": "^0.3.1"
       }
     },
     "packages/server-sdk": {
       "name": "@vonage/server-sdk",
-      "version": "3.0.0-alpha.5",
+      "version": "3.0.0-alpha.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/accounts": "^0.2.4",
-        "@vonage/applications": "^0.3.3",
-        "@vonage/messages": "^0.2.3",
-        "@vonage/number-insights": "^0.2.3",
-        "@vonage/numbers": "^0.2.3",
-        "@vonage/pricing": "^0.2.3",
-        "@vonage/server-client": "^0.4.1",
-        "@vonage/sms": "^0.3.3",
-        "@vonage/verify": "^0.2.3",
-        "@vonage/voice": "^0.2.3"
+        "@vonage/accounts": "^0.2.6",
+        "@vonage/applications": "^0.3.5",
+        "@vonage/messages": "^0.2.5",
+        "@vonage/number-insights": "^0.2.5",
+        "@vonage/numbers": "^0.2.5",
+        "@vonage/pricing": "^0.2.5",
+        "@vonage/server-client": "^0.5.0",
+        "@vonage/sms": "^0.3.5",
+        "@vonage/verify": "^0.2.5",
+        "@vonage/voice": "^0.2.5"
       }
     },
     "packages/sms": {
       "name": "@vonage/sms",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12395,10 +12395,10 @@
     },
     "packages/verify": {
       "name": "@vonage/verify",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12412,7 +12412,7 @@
     },
     "packages/vetch": {
       "name": "@vonage/vetch",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.merge": "^4.6.2",
@@ -12428,10 +12428,10 @@
     },
     "packages/video": {
       "name": "@vonage/video",
-      "version": "0.8.3",
+      "version": "0.8.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -12446,10 +12446,10 @@
     },
     "packages/voice": {
       "name": "@vonage/voice",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -14685,9 +14685,9 @@
       }
     },
     "@types/eslint": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-      "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -14747,12 +14747,12 @@
       }
     },
     "@types/jest": {
-      "version": "28.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-      "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+      "version": "28.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "requires": {
-        "jest-matcher-utils": "^28.0.0",
+        "expect": "^28.0.0",
         "pretty-format": "^28.0.0"
       }
     },
@@ -14973,14 +14973,14 @@
     "@vonage/accounts": {
       "version": "file:packages/accounts",
       "requires": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       }
     },
     "@vonage/applications": {
       "version": "file:packages/applications",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.1",
+        "@vonage/server-client": "^0.5.0",
         "jsonwebtoken": "^8.5.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
@@ -15021,7 +15021,7 @@
       "version": "file:packages/messages",
       "requires": {
         "@types/jest": "^28.1",
-        "@vonage/server-client": "^0.4.1",
+        "@vonage/server-client": "^0.5.0",
         "jest": "^28.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
@@ -15036,14 +15036,14 @@
     "@vonage/number-insights": {
       "version": "file:packages/number-insights",
       "requires": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       }
     },
     "@vonage/numbers": {
       "version": "file:packages/numbers",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.1",
+        "@vonage/server-client": "^0.5.0",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
@@ -15055,7 +15055,7 @@
     "@vonage/pricing": {
       "version": "file:packages/pricing",
       "requires": {
-        "@vonage/server-client": "^0.4.1"
+        "@vonage/server-client": "^0.5.0"
       }
     },
     "@vonage/server-client": {
@@ -15063,29 +15063,29 @@
       "requires": {
         "@vonage/auth": "^0.6.0",
         "@vonage/jwt": "^0.3.0",
-        "@vonage/vetch": "^0.2.0"
+        "@vonage/vetch": "^0.3.1"
       }
     },
     "@vonage/server-sdk": {
       "version": "file:packages/server-sdk",
       "requires": {
-        "@vonage/accounts": "^0.2.4",
-        "@vonage/applications": "^0.3.3",
-        "@vonage/messages": "^0.2.3",
-        "@vonage/number-insights": "^0.2.3",
-        "@vonage/numbers": "^0.2.3",
-        "@vonage/pricing": "^0.2.3",
-        "@vonage/server-client": "^0.4.1",
-        "@vonage/sms": "^0.3.3",
-        "@vonage/verify": "^0.2.3",
-        "@vonage/voice": "^0.2.3"
+        "@vonage/accounts": "^0.2.6",
+        "@vonage/applications": "^0.3.5",
+        "@vonage/messages": "^0.2.5",
+        "@vonage/number-insights": "^0.2.5",
+        "@vonage/numbers": "^0.2.5",
+        "@vonage/pricing": "^0.2.5",
+        "@vonage/server-client": "^0.5.0",
+        "@vonage/sms": "^0.3.5",
+        "@vonage/verify": "^0.2.5",
+        "@vonage/voice": "^0.2.5"
       }
     },
     "@vonage/sms": {
       "version": "file:packages/sms",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.1",
+        "@vonage/server-client": "^0.5.0",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
@@ -15098,7 +15098,7 @@
       "version": "file:packages/verify",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.1",
+        "@vonage/server-client": "^0.5.0",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
@@ -15123,7 +15123,7 @@
       "version": "file:packages/video",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.1",
+        "@vonage/server-client": "^0.5.0",
         "jsonwebtoken": "^8.5.1",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
@@ -15137,7 +15137,7 @@
       "version": "file:packages/voice",
       "requires": {
         "@types/jest": "^28.1.6",
-        "@vonage/server-client": "^0.4.1",
+        "@vonage/server-client": "^0.5.0",
         "nock": "^13.2.9",
         "prettier": "^2.7.1",
         "ts-jest": "^28.0.7",
@@ -21079,9 +21079,9 @@
       }
     },
     "terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -21105,17 +21105,17 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "terser": "^5.14.1"
       },
       "dependencies": {
         "jest-worker": {
@@ -21280,9 +21280,9 @@
       }
     },
     "ts-loader": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
-      "integrity": "sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.1.tgz",
+      "integrity": "sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "report-coverage": "npm run jest -- --coverage"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.6",
+    "@types/jest": "28.1.8",
     "@types/lodash.merge": "^4.6.7",
     "@types/node": "^18.6.4",
     "@types/node-fetch": "^2.6.2",

--- a/packages/accounts/tsconfig.build.json
+++ b/packages/accounts/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/accounts/tsconfig.json
+++ b/packages/accounts/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/accounts/tslint.json
+++ b/packages/accounts/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/applications/tsconfig.build.json
+++ b/packages/applications/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/applications/tsconfig.json
+++ b/packages/applications/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/applications/tslint.json
+++ b/packages/applications/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/auth/tsconfig.build.json
+++ b/packages/auth/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,14 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/auth/tslint.json
+++ b/packages/auth/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/jwt/lib/acl.ts
+++ b/packages/jwt/lib/acl.ts
@@ -1,1 +1,0 @@
-import { JWT } from '.'

--- a/packages/jwt/tsconfig.build.json
+++ b/packages/jwt/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/jwt/tsconfig.json
+++ b/packages/jwt/tsconfig.json
@@ -1,14 +1,6 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true
+    }
 }

--- a/packages/jwt/tslint.json
+++ b/packages/jwt/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/messages/lib/classes/Viber/Image.ts
+++ b/packages/messages/lib/classes/Viber/Image.ts
@@ -1,5 +1,4 @@
 import { ImageObject } from '../../interfaces/ImageObject'
-import { MessageType } from '../../interfaces/Messenger/MessageType'
 import { MessageConfig } from '../../interfaces/Viber/MessageConfig'
 import { AbstractImageMessage } from '../AbstractImageMessage'
 

--- a/packages/messages/tsconfig.build.json
+++ b/packages/messages/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/messages/tsconfig.json
+++ b/packages/messages/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/messages/tslint.json
+++ b/packages/messages/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/number-insights/tsconfig.build.json
+++ b/packages/number-insights/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/number-insights/tsconfig.json
+++ b/packages/number-insights/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/number-insights/tslint.json
+++ b/packages/number-insights/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/numbers/__tests__/numbers.test.ts
+++ b/packages/numbers/__tests__/numbers.test.ts
@@ -68,7 +68,7 @@ describe('Numbers', () => {
             })
 
         try {
-            const results = await client.buyNumber({
+            await client.buyNumber({
                 country: 'US',
                 msisdn: '12345',
                 targetApiKey: '67890',

--- a/packages/numbers/tsconfig.build.json
+++ b/packages/numbers/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/numbers/tsconfig.json
+++ b/packages/numbers/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/numbers/tslint.json
+++ b/packages/numbers/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/pricing/tsconfig.build.json
+++ b/packages/pricing/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/pricing/tsconfig.json
+++ b/packages/pricing/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/pricing/tslint.json
+++ b/packages/pricing/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/server-client/tsconfig.build.json
+++ b/packages/server-client/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/server-client/tsconfig.json
+++ b/packages/server-client/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/server-client/tslint.json
+++ b/packages/server-client/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/server-sdk/tsconfig.build.json
+++ b/packages/server-sdk/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/server-sdk/tsconfig.json
+++ b/packages/server-sdk/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/server-sdk/tslint.json
+++ b/packages/server-sdk/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/sms/lib/classes/Error/MessageSendAllFailure.ts
+++ b/packages/sms/lib/classes/Error/MessageSendAllFailure.ts
@@ -1,4 +1,4 @@
-import { Message, SendSMSResponse } from '../../types'
+import { SendSMSResponse } from '../../types'
 
 export class MessageSendAllFailure extends Error {
     protected response: SendSMSResponse

--- a/packages/sms/lib/types.ts
+++ b/packages/sms/lib/types.ts
@@ -1,5 +1,5 @@
 import { AuthOpts, AuthInterface } from '@vonage/auth'
-import { VetchError, VetchResponse, VetchOptions } from '@vonage/vetch'
+import { VetchResponse, VetchOptions } from '@vonage/vetch'
 
 export type SMSClassParameters = AuthOpts &
     VetchOptions & {

--- a/packages/sms/tsconfig.build.json
+++ b/packages/sms/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/sms/tsconfig.json
+++ b/packages/sms/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/sms/tslint.json
+++ b/packages/sms/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/verify/tsconfig.build.json
+++ b/packages/verify/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/verify/tsconfig.json
+++ b/packages/verify/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/verify/tslint.json
+++ b/packages/verify/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/vetch/__tests__/vetch.test.ts
+++ b/packages/vetch/__tests__/vetch.test.ts
@@ -142,7 +142,7 @@ describe('option configuration', () => {
 
         nock(url, options).get('/').reply(200)
         let inst = new Vetch()
-        let res = await inst.request({ url })
+        await inst.request({ url })
     })
 })
 

--- a/packages/vetch/lib/types.ts
+++ b/packages/vetch/lib/types.ts
@@ -1,6 +1,5 @@
 import http from 'node:http'
 import https from 'node:https'
-import URL from 'url'
 
 export class VetchError extends Error {
     code?: string

--- a/packages/vetch/lib/vetch.ts
+++ b/packages/vetch/lib/vetch.ts
@@ -16,7 +16,6 @@ import { stringify } from 'querystring'
 import merge from 'lodash.merge'
 import http from 'node:http'
 import https from 'node:https'
-import URL from 'url'
 
 import {
     VetchError,
@@ -25,7 +24,6 @@ import {
     ResponseTypes,
     Headers,
 } from './types'
-import { Url } from 'url'
 
 export class Vetch {
     defaults: VetchOptions

--- a/packages/vetch/tsconfig.build.json
+++ b/packages/vetch/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/vetch/tsconfig.json
+++ b/packages/vetch/tsconfig.json
@@ -1,14 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "strict": false,
-      "lib": ["ES6"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/vetch/tslint.json
+++ b/packages/vetch/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/video/__tests__/video.test.ts
+++ b/packages/video/__tests__/video.test.ts
@@ -395,7 +395,7 @@ describe('video', () => {
       .delete('/v2/project/abcd-1234/archive/b40ef09b-3811-4726-b508-e41a0f96c68f')
       .reply(204);
 
-    const resp = await client.deleteArchive("b40ef09b-3811-4726-b508-e41a0f96c68f");
+    await client.deleteArchive("b40ef09b-3811-4726-b508-e41a0f96c68f");
   });
 
   test("can update an archive layout", async () => {

--- a/packages/video/tsconfig.build.json
+++ b/packages/video/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/video/tsconfig.json
+++ b/packages/video/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/video/tslint.json
+++ b/packages/video/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/packages/voice/lib/classes/NCCO/NCCOBuilder.ts
+++ b/packages/voice/lib/classes/NCCO/NCCOBuilder.ts
@@ -1,6 +1,5 @@
 import { isNCCOSerializable } from '../../interfaces/NCCO/Serializable'
 import { Action } from '../../ncco'
-import { Serializable } from '../../ncco'
 
 export class NCCOBuilder {
     protected actions = []

--- a/packages/voice/tsconfig.build.json
+++ b/packages/voice/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": [
+        "lib/**/*"
+    ]
+}

--- a/packages/voice/tsconfig.json
+++ b/packages/voice/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "outDir": "dist",
-      "rootDir": "lib",
-      "strict": false,
-      "lib": ["ES6", "DOM"],
-      "module": "commonjs",
-      "target": "ES6",
-      "moduleResolution": "node",
-      "esModuleInterop": true,
-      "skipDefaultLibCheck": true
-  },
-  "include": ["lib/**/*"]
+    "extends": "../../tsconfig.json"
 }

--- a/packages/voice/tslint.json
+++ b/packages/voice/tslint.json
@@ -1,3 +1,0 @@
-{
-   "extends": ["tslint:recommended", "tslint-config-prettier"]
-}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "declaration": true,
+        "importHelpers": true,
+        "noUnusedLocals": true,
+        "pretty": true,
+        "strict": false,
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true
+    },
+    "exclude": [
+        "dist",
+        "node_modules",
+        "**/*.test.*"
+    ],
+    "ts-node": {
+        "compilerOptions": {
+            "module": "commonjs"
+        }
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,11 @@
 {
-  "compilerOptions": {
-      "declaration": true,
-      "sourceMap": true,
-      "noImplicitReturns": true,
-      "noUnusedLocals": true,
-      "strict": false,
-      "esModuleInterop": true,
-      "target": "es6",
-      "moduleResolution": "node",
-      "module": "CommonJS",
-      "types": ["node", "jest"],
-      "baseUrl": "../"
-  }
+    "extends": "./tsconfig.build.json",
+
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@vonage/*": ["packages/*/lib"]
+        },
+        "noEmit": true
+    }
 }


### PR DESCRIPTION
Cleaning up Typescript build files 

## Description
Having multiple `tsconfig.json` files makes it difficult to manage the build process. Having one central config file for all the packages helps reduce DRY config options while still allowing finer control over the build process. There are two different files used to allow separation from building and testing. 

## Motivation and Context
Reduces DRY configs and makes building typescript more manageable 

## Testing Details
Run `tsc --build --verbose` and confirm that all typescript files built without errors

## Example Output or Screenshots (if appropriate)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.