### PR TITLE
fix: dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "2.12.0-beta.2",
       "license": "Apache 2.0",
       "dependencies": {
-        "@babel/eslint-parser": "^7.13.10",
-        "@babel/eslint-plugin": "^7.13.10",
         "jsonwebtoken": "^8.4.0",
         "query-string": "^7.1.1",
         "request": "^2.88.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
     "@babel/register": "^7.13.8",
+    "@babel/eslint-parser": "^7.13.10",
+    "@babel/eslint-plugin": "^7.13.10",
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-plugin-istanbul": "^6.0.0",
     "bluebird": "^3.5.3",
@@ -72,8 +74,6 @@
     "sinon-expect": "^0.3.0"
   },
   "dependencies": {
-    "@babel/eslint-parser": "^7.13.10",
-    "@babel/eslint-plugin": "^7.13.10",
     "jsonwebtoken": "^8.4.0",
     "query-string": "^7.1.1",
     "request": "^2.88.2",


### PR DESCRIPTION
Removes `@bable/eslint-parser` and `@babel/eslint-plugin` from the dependencies

## Description
This was causing issues when using the SDK in the browser

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.