### PR TITLE
fix: Fixed issue with WA Template interface from older, incorrect spec

### DIFF
--- a/packages/messages/__tests__/messages.test.ts
+++ b/packages/messages/__tests__/messages.test.ts
@@ -104,7 +104,7 @@ describe('Messages', () => {
         ${new MessengerVideo({ url: 'http://example.com/video.mp4' }, '12225551234', '13335551234')}                                          | ${'video'}
         ${new WhatsAppFile({ url: 'http://example.com/file.pdf' }, '12225551234', '13335551234')}                                             | ${'file'}
         ${new MessengerFile({ url: 'http://example.com/file.pdf' }, '12225551234', '13335551234')}                                            | ${'file'}
-        ${new TemplateMessage({ name: 'MyNamespace:MyTemplate', parameters: [{ key: 'Bob Smith' }] }, '12225551234', '13335551234', 'en-GB')} | ${['template', 'whatsapp']}
+        ${new TemplateMessage({ name: 'MyNamespace:MyTemplate', parameters: ['Bob Smith'] }, '12225551234', '13335551234', 'en-GB')} | ${['template', 'whatsapp']}
         ${new CustomMessage({ type: 'template', template: {} }, '12225551234', '13335551234')}                                                | ${'custom'}
     `(
         'can send various multimedia messages',

--- a/packages/messages/lib/interfaces/WhatsApp/MessageTemplate.ts
+++ b/packages/messages/lib/interfaces/WhatsApp/MessageTemplate.ts
@@ -1,4 +1,4 @@
 export interface MessageTemplate {
     name: string
-    parameters: { key: string }[]
+    parameters: string[]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the WhatsApp template parameters to a `string[]` versus the older, incorrect definition.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This module was built way back when Messages v1 was first deployed, but the OpenAPI spec at the time was incorrect. This code never got updated to reflect the fix in the OpenAPI spec.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.