### PR TITLE
fix: Allow features to be searched in available numbers

### DIFF
--- a/packages/numbers/__tests__/numbers.test.ts
+++ b/packages/numbers/__tests__/numbers.test.ts
@@ -15,6 +15,7 @@ import * as types from '../lib/types'
 import nock from 'nock'
 import { Auth } from '@vonage/auth'
 import { Numbers } from '../lib/index'
+import { Feature } from '../lib/enums/Feature'
 
 const BASE_URL = 'https://rest.nexmo.com'.replace(/\/+$/, '')
 
@@ -128,6 +129,105 @@ describe('Numbers', () => {
             .reply(200, resp)
 
         const results = await client.getAvailableNumbers({ country: 'US' })
+        expect(results.count).toEqual(1234)
+        expect(results.numbers.length).toEqual(1)
+        expect(results.numbers[0].country).toEqual(resp.numbers[0].country)
+    })
+
+    test('Searching for number features joins correctly with 1 element', async () => {
+        const resp = {
+            count: 1234,
+            numbers: [
+                {
+                    country: 'GB',
+                    msisdn: '447700900000',
+                    type: 'mobile-lvn',
+                    cost: '1.25',
+                    features: ['VOICE', 'SMS', 'MMS'],
+                },
+            ],
+        }
+
+        nock(BASE_URL)
+            .get(`/number/search`)
+            .query({
+                api_key: '12345',
+                api_secret: 'ABCDE',
+                country: 'US',
+                features: 'MMS',
+            })
+            .reply(200, resp)
+
+        const results = await client.getAvailableNumbers({
+            country: 'US',
+            features: [Feature.MMS],
+        })
+        expect(results.count).toEqual(1234)
+        expect(results.numbers.length).toEqual(1)
+        expect(results.numbers[0].country).toEqual(resp.numbers[0].country)
+    })
+
+    test('Searching for number features joins correctly with 2 elements', async () => {
+        const resp = {
+            count: 1234,
+            numbers: [
+                {
+                    country: 'GB',
+                    msisdn: '447700900000',
+                    type: 'mobile-lvn',
+                    cost: '1.25',
+                    features: ['VOICE', 'SMS', 'MMS'],
+                },
+            ],
+        }
+
+        nock(BASE_URL)
+            .get(`/number/search`)
+            .query({
+                api_key: '12345',
+                api_secret: 'ABCDE',
+                country: 'US',
+                features: 'VOICE,MMS',
+            })
+            .reply(200, resp)
+
+        const results = await client.getAvailableNumbers({
+            country: 'US',
+            features: [Feature.MMS, Feature.VOICE],
+        })
+        expect(results.count).toEqual(1234)
+        expect(results.numbers.length).toEqual(1)
+        expect(results.numbers[0].country).toEqual(resp.numbers[0].country)
+    })
+
+    test('Searching for number features joins correctly with 3 elements', async () => {
+        const resp = {
+            count: 1234,
+            numbers: [
+                {
+                    country: 'GB',
+                    msisdn: '447700900000',
+                    type: 'mobile-lvn',
+                    cost: '1.25',
+                    features: ['VOICE', 'SMS', 'MMS'],
+                },
+            ],
+        }
+
+        nock(BASE_URL)
+            .get(`/number/search`)
+            .query({
+                api_key: '12345',
+                api_secret: 'ABCDE',
+                country: 'US',
+                features: 'SMS,MMS,VOICE',
+            })
+            .reply(200, resp)
+
+        const results = await client.getAvailableNumbers({
+            country: 'US',
+            features: [Feature.MMS, Feature.VOICE, Feature.SMS],
+        })
         expect(results.count).toEqual(1234)
         expect(results.numbers.length).toEqual(1)
         expect(results.numbers[0].country).toEqual(resp.numbers[0].country)

--- a/packages/numbers/lib/enums/Feature.ts
+++ b/packages/numbers/lib/enums/Feature.ts
@@ -1,0 +1,5 @@
+export enum Feature {
+    'MMS' = 'MMS',
+    'SMS' = 'SMS',
+    'VOICE' = 'VOICE',
+}

--- a/packages/numbers/lib/enums/LineType.ts
+++ b/packages/numbers/lib/enums/LineType.ts
@@ -1,0 +1,5 @@
+export enum LineType {
+    'LANDLINE' = 'landline',
+    'MOBILE-LVN' = 'mobile-lvn',
+    'LANDLINE-TOLL-FREE' = 'landline-toll-free',
+}

--- a/packages/numbers/lib/enums/SearchPattern.ts
+++ b/packages/numbers/lib/enums/SearchPattern.ts
@@ -1,0 +1,5 @@
+export enum SearchPattern {
+    'START_WITH' = 0,
+    'CONTAINS' = 1,
+    'ENDS_WITH' = 2,
+}

--- a/packages/numbers/lib/types.ts
+++ b/packages/numbers/lib/types.ts
@@ -1,5 +1,8 @@
 import { AuthOpts, AuthInterface } from '@vonage/auth'
 import { VetchResponse, VetchOptions } from '@vonage/vetch'
+import { Feature } from './enums/Feature'
+import { SearchPattern } from './enums/SearchPattern'
+import { LineType } from './enums/LineType'
 
 export type NumbersClassParameters = AuthOpts &
     VetchOptions & {
@@ -38,9 +41,9 @@ export interface NumbersQueryParams {
 export interface NumbersAvailableNumber {
     country?: Country
     msisdn?: string
-    type?: string
+    type?: LineType
     cost?: string
-    features?: string[]
+    features?: Feature[]
 }
 
 export type Country = string
@@ -89,8 +92,8 @@ export interface NumbersOwnedNumber {
     country?: Country
     msisdn?: string
     moHttpUrl?: string
-    type?: string
-    features?: string[]
+    type?: LineType
+    features?: Feature[]
     voiceCallbackType?: string
     voiceCallbackValue?: string
     messagesCallbackType?: string
@@ -99,8 +102,10 @@ export interface NumbersOwnedNumber {
 
 export interface NumbersSearchFilter {
     country: Country
+    type?: LineType
     pattern?: string
-    searchPattern?: number
+    searchPattern?: SearchPattern
+    features?: Feature[]
     size?: number
     index?: number
 }
@@ -118,7 +123,7 @@ export interface NumbersOwnedFilter {
     applicationId?: string
     hasApplication?: boolean
     pattern?: string
-    searchPattern?: number
+    searchPattern?: SearchPattern
     size?: number
     index?: number
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Searching for available numbers did not allow searching by feature, so added that. Also added some helper enums for searching to make understanding the options better.

Searching by feature also makes sure that the options are always in the correct order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When working on a demo, I could not search by feature so needed this. 

The additional enums make it easier to understand what some of the options are.

The feature sorting also removes the need for the developer to know what order to put the features in, the SDK will re-order them. The developer just needs to chuck the features into an array, everything else is handled.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.