### PR TITLE
fix: Change Numbers API to make URL Form Encoded requests

### DIFF
--- a/packages/numbers/__tests__/numbers.test.ts
+++ b/packages/numbers/__tests__/numbers.test.ts
@@ -33,13 +33,14 @@ describe('Numbers', () => {
     test('buyNumber()', async () => {
         nock(BASE_URL)
             .persist()
-            .post(`/number/buy`, {
-                api_key: '12345',
-                api_secret: 'ABCDE',
-                country: 'US',
-                msisdn: '12345',
-                target_api_key: '67890',
-            })
+            .post(
+                `/number/buy?api_key=12345&api_secret=ABCDE`,
+                new URLSearchParams([
+                    ['target_api_key', '67890'],
+                    ['country', 'US'],
+                    ['msisdn', '12345'],
+                ]).toString()
+            )
             .reply(200, { 'error-code': '200', 'error-code-label': 'success' })
 
         const results = await client.buyNumber({
@@ -56,13 +57,14 @@ describe('Numbers', () => {
         )
         nock(BASE_URL)
             .persist()
-            .post(`/number/buy`, {
-                api_key: 'badkey',
-                api_secret: 'badsecret',
-                country: 'US',
-                msisdn: '12345',
-                target_api_key: '67890',
-            })
+            .post(
+                `/number/buy?api_key=badkey&api_secret=badsecret`,
+                new URLSearchParams([
+                    ['target_api_key', '67890'],
+                    ['country', 'US'],
+                    ['msisdn', '12345'],
+                ]).toString()
+            )
             .reply(401, {
                 'error-code': '401',
                 'error-code-label': 'authentication failed',
@@ -235,13 +237,14 @@ describe('Numbers', () => {
 
     test('cancelNumber()', async () => {
         nock(BASE_URL)
-            .post(`/number/cancel`, {
-                api_key: '12345',
-                api_secret: 'ABCDE',
-                country: 'US',
-                msisdn: '12345',
-                target_api_key: '67890',
-            })
+            .post(
+                `/number/cancel?api_key=12345&api_secret=ABCDE`,
+                new URLSearchParams([
+                    ['target_api_key', '67890'],
+                    ['country', 'US'],
+                    ['msisdn', '12345'],
+                ]).toString()
+            )
             .reply(200, { 'error-code': '200', 'error-code-label': 'success' })
 
         const results = await client.cancelNumber({
@@ -254,16 +257,20 @@ describe('Numbers', () => {
 
     test('updateNumber()', async () => {
         nock(BASE_URL)
-            .post(`/number/update`, {
-                api_key: '12345',
-                api_secret: 'ABCDE',
-                country: 'US',
-                msisdn: '12345',
-                app_id: '123abc',
-                voiceCallbackType: 'app',
-                voiceCallbackValue: 'https://www.example.com/webhook',
-                voiceStatusCallback: 'https://www.example.com/webhook/events',
-            })
+            .post(
+                `/number/update?api_key=12345&api_secret=ABCDE`,
+                new URLSearchParams([
+                    ['app_id', '123abc'],
+                    ['country', 'US'],
+                    ['msisdn', '12345'],
+                    ['voiceCallbackType', 'app'],
+                    ['voiceCallbackValue', 'https://www.example.com/webhook'],
+                    [
+                        'voiceStatusCallback',
+                        'https://www.example.com/webhook/events',
+                    ],
+                ]).toString()
+            )
             .reply(200, { 'error-code': '200', 'error-code-label': 'success' })
 
         const results = await client.updateNumber({

--- a/packages/numbers/lib/numbers.ts
+++ b/packages/numbers/lib/numbers.ts
@@ -1,4 +1,4 @@
-import { Client } from '@vonage/server-client'
+import { AuthenticationType, Client } from '@vonage/server-client'
 import { Feature } from './enums/Feature'
 import {
     NumbersAvailableList,
@@ -23,12 +23,14 @@ const remapObjects = <T, O>(mapping, newObject: T, oldObject: O): T => {
 }
 
 export class Numbers extends Client {
+    protected authType = AuthenticationType.QUERY_KEY_SECRET
+
     public async buyNumber(
         params?: NumbersParams
     ): Promise<NumbersEmptyResponse> {
         const mapping = { target_api_key: 'targetApiKey' }
         const data = remapObjects(mapping, {}, params)
-        const resp = await this.sendPostRequest<NumbersEmptyResponse>(
+        const resp = await this.sendFormSubmitRequest<NumbersEmptyResponse>(
             `${this.config.restHost}/number/buy`,
             data
         )
@@ -44,7 +46,7 @@ export class Numbers extends Client {
     ): Promise<NumbersEmptyResponse> {
         const mapping = { target_api_key: 'targetApiKey' }
         const data = remapObjects(mapping, {}, params)
-        const resp = await this.sendPostRequest<NumbersEmptyResponse>(
+        const resp = await this.sendFormSubmitRequest<NumbersEmptyResponse>(
             `${this.config.restHost}/number/cancel`,
             data
         )
@@ -119,7 +121,7 @@ export class Numbers extends Client {
             app_id: 'applicationId',
         }
         const data = remapObjects(mapping, {}, params)
-        const resp = await this.sendPostRequest<NumbersOwnedNumber>(
+        const resp = await this.sendFormSubmitRequest<NumbersOwnedNumber>(
             `${this.config.restHost}/number/update`,
             data
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the POST requests of the Numbers API to use URL form encoded requests instead of JSON bodies. Also forced the Numbers API to make sure the API Key and Secret are always in the header via the correct auth type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Looks like this was a long-standing bug with the v3 code, and when everything was transitioned to using the `server-client` package it was moved to normal POST requests with a JSON body instead of using form encoded requests.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, and used in a demo app

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.