### PR TITLE
fix: Set the proper content type when we send put/patch/post

### DIFF
--- a/packages/applications/__tests__/applications.test.ts
+++ b/packages/applications/__tests__/applications.test.ts
@@ -218,7 +218,14 @@ describe('applications', () => {
       },
     };
 
-    nock(BASE_URL).persist().put('/v2/applications/78d335fa-323d-0114-9c3d-d6f0d48968cf').reply(200, expectedResponse);
+    nock(BASE_URL, {
+      reqheaders: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .persist()
+      .put('/v2/applications/78d335fa-323d-0114-9c3d-d6f0d48968cf')
+      .reply(200, expectedResponse);
 
     const app: Application = {
       id: '78d335fa-323d-0114-9c3d-d6f0d48968cf',

--- a/packages/server-client/lib/client.ts
+++ b/packages/server-client/lib/client.ts
@@ -112,6 +112,9 @@ export abstract class Client {
             url,
             body: new URLSearchParams(payload),
             method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
         }
 
         if (!payload) {
@@ -146,6 +149,9 @@ export abstract class Client {
             url,
             data: payload,
             method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+            },
         }
 
         if (!payload) {
@@ -163,6 +169,9 @@ export abstract class Client {
             url,
             data: payload,
             method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
         }
 
         if (!payload) {
@@ -180,6 +189,9 @@ export abstract class Client {
             url,
             data: payload,
             method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
         }
 
         if (!payload) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Applications API requires that the `Content-Type` header be sent on modification requests. This goes ahead and adds them to the base requests as we always send JSON for `PUT`, `PATCH`, and most `POST` requests. It sets the `application/x-www-form-urlencoded` value for URL encoded bodies as well, as that is a separate `POST` request

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug that was encountered by CSE testing v3

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.