### PR TITLE
fix: Correct our return types when sending SMS

### DIFF
--- a/packages/sms/__tests__/classes/Error/MessageSendPartialFalure.test.ts
+++ b/packages/sms/__tests__/classes/Error/MessageSendPartialFalure.test.ts
@@ -17,6 +17,7 @@ describe('SMS Partial Failure Error', () => {
     test('can get messages', async () => {
         const resp = {
             'message-count': '2',
+            messageCount: 2,
             messages: [
                 {
                     to: '447700900000',

--- a/packages/sms/__tests__/sms.test.ts
+++ b/packages/sms/__tests__/sms.test.ts
@@ -60,5 +60,44 @@ describe('SMS', () => {
             text: 'Sample SMS Text',
         })
         expect(results['message-count']).toEqual('1')
+        expect(results.messageCount).toEqual(1)
+        for (let i = 0; i < results.messages.length; i++) {
+            expect(resp.messages[i].to).toEqual(results.messages[i].to)
+            expect(resp.messages[i]['message-id']).toEqual(
+                results.messages[i].messageId
+            )
+            expect(resp.messages[i]['message-id']).toEqual(
+                results.messages[i]['message-id']
+            )
+            expect(resp.messages[i].status).toEqual(results.messages[i].status)
+            expect(resp.messages[i]['remaining-balance']).toEqual(
+                results.messages[i].remainingBalance
+            )
+            expect(resp.messages[i]['remaining-balance']).toEqual(
+                results.messages[i]['remaining-balance']
+            )
+            expect(resp.messages[i]['message-price']).toEqual(
+                results.messages[i].messagePrice
+            )
+            expect(resp.messages[i]['message-price']).toEqual(
+                results.messages[i]['message-price']
+            )
+            expect(resp.messages[i].network).toEqual(
+                results.messages[i].network
+            )
+            expect(resp.messages[i]['client-ref']).toEqual(
+                results.messages[i]['client-ref']
+            )
+            expect(resp.messages[i]['client-ref']).toEqual(
+                results.messages[i].clientRef
+            )
+            expect(resp.messages[i]['account-ref']).toEqual(
+                results.messages[i].accountRef
+            )
+            expect(resp.messages[i]['account-ref']).toEqual(
+                results.messages[i]['account-ref']
+            )
+        }
+        expect(results.messageCount).toEqual(1)
     })
 })

--- a/packages/sms/lib/types.ts
+++ b/packages/sms/lib/types.ts
@@ -19,7 +19,11 @@ export interface SMSGeneralResponse {
 }
 
 export interface SendSMSResponse {
+    /**
+     * @deprecated Use messageCount instead
+     */
     'message-count': string
+    messageCount: number
     messages: Message[]
 }
 
@@ -78,12 +82,32 @@ export interface InboundMessage {
 export interface Message {
     to?: string
     messageId?: string
+    /**
+     * @deprecated Use messageId instead
+     */
+    'message-id'?: string
     status?: string
     remainingBalance?: string
+    /**
+     * @deprecated Use remainingBalance instead
+     */
+    'remaining-balance'?: string
     messagePrice?: string
+    /**
+     * @deprecated Use messagePrice
+     */
+    'message-price'?: string
     network?: string
     clientRef?: string
+    /**
+     * @deprecated Use clientRef instead
+     */
+    'client-ref'?: string
     accountRef?: string
+    /**
+     * @deprecated Use accountRef instead
+     */
+    'account-ref'?: string
 }
 
 export interface ModelError {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Corrects the type definition for the returned SMS responses to match the original declaration. This also adds keys with appropriate deprecation notices to not break existing code. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Per #742 , the definitions we provided for the return response did not match the API. Looks like as this was an early module, we never finished cleaning up to make it match.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.