### PR TITLE
fix: allow no filter when getting owned numbers, require filter when searching available numbers

### DIFF
--- a/packages/numbers/__tests__/numbers.test.ts
+++ b/packages/numbers/__tests__/numbers.test.ts
@@ -111,6 +111,36 @@ describe('Numbers', () => {
         expect(results.numbers[0].country).toEqual(resp.numbers[0].country)
     })
 
+    test('can get all owned numbers with no filter', async () => {
+        const resp = {
+            count: 1,
+            numbers: [
+                {
+                    country: 'GB',
+                    msisdn: '447700900000',
+                    moHttpUrl: 'https://example.com/webhooks/inbound-sms',
+                    type: 'mobile-lvn',
+                    features: ['VOICE', 'SMS', 'MMS'],
+                    messagesCallbackType: 'app',
+                    messagesCallbackValue:
+                        'aaaaaaaa-bbbb-cccc-dddd-0123456789ab',
+                    voiceCallbackType: 'app',
+                    voiceCallbackValue: 'aaaaaaaa-bbbb-cccc-dddd-0123456789ab',
+                },
+            ],
+        }
+
+        nock(BASE_URL)
+            .get(`/account/numbers`)
+            .query({ api_key: '12345', api_secret: 'ABCDE' })
+            .reply(200, resp)
+
+        const results = await client.getOwnedNumbers()
+        expect(results.count).toEqual(1)
+        expect(results.numbers.length).toEqual(1)
+        expect(results.numbers[0].country).toEqual(resp.numbers[0].country)
+    })
+
     test('getAvailableNumbers()', async () => {
         const resp = {
             count: 1234,

--- a/packages/numbers/lib/numbers.ts
+++ b/packages/numbers/lib/numbers.ts
@@ -58,7 +58,7 @@ export class Numbers extends Client {
     }
 
     public async getAvailableNumbers(
-        filter?: NumbersSearchFilter
+        filter: NumbersSearchFilter
     ): Promise<NumbersAvailableList> {
         const mapping = {
             search_pattern: 'searchPattern',
@@ -101,6 +101,10 @@ export class Numbers extends Client {
     public async getOwnedNumbers(
         filter?: NumbersOwnedFilter
     ): Promise<NumbersOwnedList> {
+        if (!filter) {
+            filter = {}
+        }
+
         const mapping = {
             application_id: 'applicationId',
             has_application: 'hasApplication',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed it so a user can pass in an empty filter when getting their owned numbers
Changed it so that a user is forced to pass in a filter when searching for available numbers, as a country is always required for that API call

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug found when building out a demo app. While you can pass in an empty filter for getting owned numbers, it's more intuitive to allow the user to just not specify one at all.

When checking the above, came across that we allowed an optional filter on the getting available numbers call. You always have to at least pass in a country, so this enforces that rule as the user would have to pass in one to get a valid result anyway.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.