### PR TITLE
fix(voice): Fixed syntax for setting action on some NCCOs

### DIFF
--- a/packages/voice/lib/classes/NCCO/Connect.ts
+++ b/packages/voice/lib/classes/NCCO/Connect.ts
@@ -5,7 +5,7 @@ import { Serializable } from '../../ncco'
 import { CallEndpoint } from '../../types/Endpoint/CallEndpoint'
 
 export class Connect implements ConnectAction, Serializable {
-    action: 'connect'
+    action: string = 'connect'
     endpoint: CallEndpoint[]
     from?: string
     randomFromNumber?: boolean

--- a/packages/voice/lib/classes/NCCO/Conversation.ts
+++ b/packages/voice/lib/classes/NCCO/Conversation.ts
@@ -2,7 +2,7 @@ import { ConversationAction } from '../../interfaces/NCCO/ConversationAction'
 import { Serializable } from '../../ncco'
 
 export class Conversation implements ConversationAction, Serializable {
-    action: 'conversation'
+    action: string = 'conversation'
     name: string
     musicOnHoldUrl?: string[]
     startOnEnter?: boolean

--- a/packages/voice/lib/classes/NCCO/Notify.ts
+++ b/packages/voice/lib/classes/NCCO/Notify.ts
@@ -2,7 +2,7 @@ import { NotifyAction } from '../../interfaces/NCCO/NotifyAction'
 import { Serializable } from '../../ncco'
 
 export class Notify implements NotifyAction, Serializable {
-    action: 'notify'
+    action: string = 'notify'
     payload: {
         [key: string]: string
     }

--- a/packages/voice/lib/classes/NCCO/Record.ts
+++ b/packages/voice/lib/classes/NCCO/Record.ts
@@ -2,7 +2,7 @@ import { RecordingFormat } from '../../enums/NCCO/RecordingFormat'
 import { RecordAction } from '../../interfaces/NCCO/RecordAction'
 
 export class Record implements RecordAction {
-    action: 'record'
+    action: string = 'record'
     format?: RecordingFormat
     protected wrappedSplit?: string
     protected wrappedChannels?: number

--- a/packages/voice/lib/classes/NCCO/Stream.ts
+++ b/packages/voice/lib/classes/NCCO/Stream.ts
@@ -2,7 +2,7 @@ import { StreamAction } from '../../interfaces/NCCO/StreamAction'
 import { Serializable } from '../../ncco'
 
 export class Stream implements StreamAction, Serializable {
-    action: 'stream'
+    action: string = 'stream'
     streamUrl: string[]
     level?: number
     bargeIn?: boolean


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some of the NCCO actions had their `action` property set to undefined because the typehint was set to the value, not the property. This corrects that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This generated invalid NCCOs for these types

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate)
Code:
```js
builder.addAction(new Talk("Hello"));
builder.addAction(
  new Stream("https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3")
);

console.log(builder.build());
```

Output:
```json
[
  Talk {
    action: 'talk',
    text: 'Hello',
    bargeIn: undefined,
    loop: undefined,
    level: undefined,
    language: undefined,
    style: undefined,
    premium: undefined
  },
  Stream {
    action: undefined, <--- Invalid action
    streamUrl: [ 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3' ],
    level: undefined,
    bargeIn: undefined,
    loop: undefined
  }
]
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.