### PR TITLE
fix(jwt): Fix ttl in claims

### DIFF
--- a/packages/jwt/__tests__/jwt.test.ts
+++ b/packages/jwt/__tests__/jwt.test.ts
@@ -89,6 +89,7 @@ describe('Token Generator', () => {
     const decoded = verify(token, privateKey, { algorithms: ['RS256'] });
     expect(decoded.exp).toEqual(decoded.iat + ttl);
     expect(decoded.sub).toEqual(subject);
+    expect(decoded).not.toHaveProperty('ttl');
     expect(decoded.acl).toMatchObject(acl);
   });
 });

--- a/packages/jwt/lib/jwt.ts
+++ b/packages/jwt/lib/jwt.ts
@@ -48,11 +48,14 @@ export class JWT implements JWTInterface {
   private validateOptions(opts?: GeneratorOptions): Claims {
     const now = parseInt((Date.now() / 1000).toString(), 10);
 
+    const ttl = opts?.ttl || 900;
+    delete opts.ttl;
+
     const claims: Claims = {
       ...opts,
       jti: opts?.jti || uuidv4(),
       iat: opts?.issued_at || now,
-      exp: now + (opts?.ttl || 900),
+      exp: now + ttl,
     };
 
     if (opts?.subject) {

--- a/packages/jwt/lib/jwt.ts
+++ b/packages/jwt/lib/jwt.ts
@@ -49,7 +49,9 @@ export class JWT implements JWTInterface {
     const now = parseInt((Date.now() / 1000).toString(), 10);
 
     const ttl = opts?.ttl || 900;
-    delete opts.ttl;
+    if (opts.ttl) {
+      delete opts.ttl;
+    }
 
     const claims: Claims = {
       ...opts,

--- a/packages/jwt/lib/jwt.ts
+++ b/packages/jwt/lib/jwt.ts
@@ -49,7 +49,7 @@ export class JWT implements JWTInterface {
     const now = parseInt((Date.now() / 1000).toString(), 10);
 
     const ttl = opts?.ttl || 900;
-    if (opts.ttl) {
+    if (opts?.ttl) {
       delete opts.ttl;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When passing in a `ttl` to generate a new token, we accidentally leave the `ttl` parameter in the claims. This is causing a problem with tokens being rejected. The `exp` _is_ calculated properly, but we just leave the additional `ttl` claim there due to object unpacking.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This breaks JWT validation

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a unit test

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.