### PR TITLE
fix(voice): Force NCCO actions to set value for NCCO type to avoid JS problems

### DIFF
--- a/packages/voice/lib/classes/NCCO/Connect.ts
+++ b/packages/voice/lib/classes/NCCO/Connect.ts
@@ -63,7 +63,7 @@ export class Connect implements ConnectAction, Serializable {
 
   serializeToNCCO() {
     const data: ConnectAction = {
-      action: this.action,
+      action: NCCOActions.CONNECT,
       endpoint: this.endpoint,
     };
 

--- a/packages/voice/lib/classes/NCCO/Conversation.ts
+++ b/packages/voice/lib/classes/NCCO/Conversation.ts
@@ -50,7 +50,7 @@ export class Conversation implements ConversationAction, Serializable {
 
   serializeToNCCO() {
     const data: ConversationAction = {
-      action: this.action,
+      action: NCCOActions.CONVERSATION,
       name: this.name,
     };
 

--- a/packages/voice/lib/classes/NCCO/Record.ts
+++ b/packages/voice/lib/classes/NCCO/Record.ts
@@ -127,7 +127,7 @@ export class Record implements RecordAction {
 
   serializeToNCCO(): RecordAction {
     const data: RecordAction = {
-      action: this.action,
+      action: NCCOActions.RECORD,
     };
 
     if (this.format) {

--- a/packages/voice/lib/classes/NCCO/Stream.ts
+++ b/packages/voice/lib/classes/NCCO/Stream.ts
@@ -30,7 +30,7 @@ export class Stream implements StreamAction, Serializable {
 
   serializeToNCCO() {
     const data: StreamAction = {
-      action: this.action,
+      action: NCCOActions.STREAM,
       streamUrl: this.streamUrl,
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When serializing an NCCO to a JS object, set the action to a static value instead of relying on the object's `this.action` property.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When making the JS Object serializations, using `action: this.action` to generate the resulting objects would always result in a blank value. This seems to work fine on some versions of node, for the unit tests, and in TS, but when running in a pure JS environment the resulting value was blank. Since NCCOs have a static action value based on their type, this just sets the value directly during deserialization.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, as well as manual testing to help build the patch.

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.