### PR TITLE
fix(voice): Fixed response types on file downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install typescript
-        run: npm install -g typescript npm${{ matrix.npm_version }}
+        run: npm install -g typescript
 
       - name: Install packages
         run: npm install

--- a/packages/proactive-connect/package.json
+++ b/packages/proactive-connect/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@vonage/server-client": "^1.8.1",
-    "@vonage/vetch": "1.5.0",
     "form-data": "^4.0.0",
     "lodash.pick": "^4.4.0"
   },

--- a/packages/server-client/lib/client.ts
+++ b/packages/server-client/lib/client.ts
@@ -5,6 +5,7 @@ import {
   VetchResponse,
   VetchOptions,
   HTTPMethods,
+  Vetch,
 } from '@vonage/vetch';
 import { AuthenticationType } from './enums/AuthenticationType';
 import * as transfomers from './transformers';
@@ -174,7 +175,8 @@ export abstract class Client {
   ): Promise<VetchResponse<T>> {
     request.timeout = this.config.timeout;
     request = await this.addAuthenticationToRequest(request);
-    const result = await vetchRequest<T>(request);
+    const vetch = new Vetch(this.config);
+    const result = await vetch.request<T>(request);
     return result;
   }
 }

--- a/packages/server-client/lib/types/ConfigParams.ts
+++ b/packages/server-client/lib/types/ConfigParams.ts
@@ -1,8 +1,9 @@
+import { ResponseTypes } from '@vonage/vetch';
 export type ConfigParams = {
   restHost?: string;
   apiHost?: string;
   videoHost?: string;
-  responseType?: string;
+  responseType?: ResponseTypes;
   timeout?: number;
   proactiveHost?: string;
   meetingsHost?: string;

--- a/packages/vetch/lib/enums/responseTypes.ts
+++ b/packages/vetch/lib/enums/responseTypes.ts
@@ -1,3 +1,5 @@
 export enum ResponseTypes {
-    json = 'json',
+  json = 'json',
+  stream = 'stream',
+  text = 'text',
 }

--- a/packages/vetch/lib/vetch.ts
+++ b/packages/vetch/lib/vetch.ts
@@ -69,6 +69,8 @@ export class Vetch {
     res: fetchResponse,
   ): Promise<any> {
     switch (opts.responseType) {
+    case 'stream':
+      return res.buffer();
     case 'json': {
       let data = await res.text();
       try {

--- a/packages/voice/lib/voice.ts
+++ b/packages/voice/lib/voice.ts
@@ -14,6 +14,7 @@ import {
 } from './types/index';
 
 import { CallListFilter } from './types';
+import { ResponseTypes } from '@vonage/vetch';
 
 const apiCallsToCalls = (call: CallDetailResponse): CallDetail => {
   delete call._links;
@@ -177,8 +178,18 @@ export class Voice extends Client {
   }
 
   async downloadRecording(file: string, path: string): Promise<void> {
-    const client = new FileClient(this.auth, this.config);
+    const config = this.config;
+    config.responseType = ResponseTypes.stream;
 
+    const client = new FileClient(this.auth, config);
+    return await client.downloadFile(file, path);
+  }
+
+  async downloadTranscription(file: string, path: string): Promise<void> {
+    const config = this.config;
+    config.responseType = ResponseTypes.text;
+
+    const client = new FileClient(this.auth, config);
     return await client.downloadFile(file, path);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed the response type expectations when downloading recordings and transcriptions.

This also adds a `downloadTranscription()` method to voice to make it easier to download transcriptions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By default, the `server-client` clients expect a response in JSON. This is fine for API calls as we almost always expect JSON responses, but voice recordings and transcriptions should be treated as buffers instead. This change lets recordings be downloaded using `res.buffer()` and transcripts be downloaded using `res.text()` decoding.

Note that the `FileClient` by itself could have worked directly by overriding the config option as "text" since text just act like a generic buffer, but adding a `stream` response type is semantically more clear.

## Testing Details
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.