### PR TITLE
refactor: fixing typo in ServiceType enum

### DIFF
--- a/packages/pricing/lib/enums/ServiceType.ts
+++ b/packages/pricing/lib/enums/ServiceType.ts
@@ -1,5 +1,5 @@
 export enum ServiceType {
     SMS = 'sms',
     SMS_TRANSIT = 'sms-transit',
-    VOICE = 'voice,',
+    VOICE = 'voice',
 }


### PR DESCRIPTION
## Description
I have corrected the typo in the enum from "voice," to "voice".

## Motivation and Context
There was an extra comma in the enum value causing the REST calls to fail and return a 404 error on requesting pricing for "voice"

## Testing Details
Tested in a sample project. Does not affect other areas.

## Example Output or Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.