### PR TITLE
fix(server-sdk): sms versioning

### DIFF
--- a/packages/server-sdk/package.json
+++ b/packages/server-sdk/package.json
@@ -36,7 +36,7 @@
     "@vonage/pricing": "^1.9.0",
     "@vonage/redact": "^1.8.0",
     "@vonage/server-client": "^1.9.0",
-    "@vonage/sms": "^1.9.2",
+    "@vonage/sms": "^1.9.0",
     "@vonage/users": "^1.3.0",
     "@vonage/verify": "^1.9.0",
     "@vonage/verify2": "^1.8.0",


### PR DESCRIPTION
## Description
The npm install of `vonage/server-sdk` seems to be braking due to the `vonage/sms:v1.9.2` being not found.
So I downgraded to version 1.9.0 as it's available on the monorepo.

## Motivation and Context
I can not run `npm i` and build my project. 

## Testing Details
The issue is resolved after my downgrade.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.