### PR TITLE
fix: outdated/wrong algorithm argument passed to jsonwebtoken

### DIFF
--- a/packages/jwt/lib/verifySignature.ts
+++ b/packages/jwt/lib/verifySignature.ts
@@ -44,9 +44,7 @@ export const verifySignature = (
   }
 
   try {
-    verify(jwt, privateKey, {
-      algorithms: ['RS256'],
-    });
+    verify(jwt, privateKey);
     return true;
   } catch (error) {
     log('Error when verifying token', error);

--- a/packages/jwt/lib/verifySignature.ts
+++ b/packages/jwt/lib/verifySignature.ts
@@ -44,7 +44,9 @@ export const verifySignature = (
   }
 
   try {
-    verify(jwt, privateKey);
+    verify(jwt, privateKey, {
+      algorithms: ['HS256'],
+    });
     return true;
   } catch (error) {
     log('Error when verifying token', error);


### PR DESCRIPTION
@vonage/jwt VerifySignature defaults to RS256. 

My best guess is that it's to accommodate a previous version of the authentication/authorization setup vonage had.

Either way, there is no reason for it, as JWTs contain the algorithm in the header.

Additionally, the JWTs I receive from Vonage are HS256. Meaning that this is breaking and verifyToken does not work.

There is another question as to wether this should be provided by the Vonage SDK, but that's up to you guys!

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed RS256 argument passed to verify function from jsonwebtoken.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
My webhooks recieve HS256 tokens, not RS256 from Vonage. Either way it shouldn't be defaulted as the algorithm is contained in the JWT header.

<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
No test run done, should pass though.

<!--- Include details of your testing environment, and the tests you ran to -->
--

<!--- see how your change affects other areas of the code, etc. -->
--

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
