### PR TITLE
fix(verify2): sms and silent auth updates

### DIFF
--- a/packages/verify2/__tests__/__dataSets__/verify.ts
+++ b/packages/verify2/__tests__/__dataSets__/verify.ts
@@ -253,6 +253,8 @@ export default [
             channel: Channels.SMS,
             to: '14152739164',
             app_hash: 'C0FFEE',
+            entity_id: '1101407360000017170',
+            content_id: '1107158078772563946',
           },
         ],
         locale: VerifyLocale.EN_GB,
@@ -278,6 +280,8 @@ export default [
             channel: Channels.SMS,
             to: '14152739164',
             appHash: 'C0FFEE',
+            entityId: '1101407360000017170',
+            contentId: '1107158078772563946',
           } as SMSWorkflow,
         ],
         locale: VerifyLocale.EN_GB,
@@ -494,6 +498,7 @@ export default [
           {
             channel: SilentAuthChannel.SILENT_AUTH,
             to: '14152739164',
+            redirect_url: 'https://example.com/redirect',
           },
         ],
         locale: VerifyLocale.EN_GB,
@@ -507,6 +512,7 @@ export default [
       202,
       {
         request_id: 'cef1c266-d144-485e-8915-bd2d51b06776',
+        check_url: 'https://example.com/check',
       } as VerificationResponse,
     ],
     method: 'post',
@@ -518,6 +524,7 @@ export default [
           {
             channel: SilentAuthChannel.SILENT_AUTH,
             to: '14152739164',
+            redirectUrl: 'https://example.com/redirect',
           } as SilentAuthWorkflow,
         ],
         locale: VerifyLocale.EN_GB,
@@ -529,6 +536,7 @@ export default [
     ],
     expected: {
       requestId: 'cef1c266-d144-485e-8915-bd2d51b06776',
+      checkUrl: 'https://example.com/check',
     },
   },
   {

--- a/packages/verify2/lib/types/request.ts
+++ b/packages/verify2/lib/types/request.ts
@@ -6,4 +6,9 @@ export type Request = {
    * The unique identifier for the request.
    */
   requestId: string;
+
+  /**
+   * The URL to check the status of the request.
+   */
+  checkUrl?: string;
 };

--- a/packages/verify2/lib/types/silentAuthWorkflow.ts
+++ b/packages/verify2/lib/types/silentAuthWorkflow.ts
@@ -13,4 +13,9 @@ export type SilentAuthWorkflow = {
    * The target identifier for Silent Authentication.
    */
   to: string;
+
+  /**
+   * The redirect URL for Silent Authentication.
+   */
+  redirectUrl: string;
 };

--- a/packages/verify2/lib/types/smsWorkflow.ts
+++ b/packages/verify2/lib/types/smsWorkflow.ts
@@ -16,6 +16,26 @@ export type SMSWorkflow = {
   to: string;
 
   /**
+   * An optional sender number, in the E.164 format.
+   * Don't use a leading + or 00 when entering a phone number, start with the
+   * country code, for example, 447700900000.
+   *
+   * @remarks
+   * If no from number is given, the request will default to the brand.
+   */
+  from?: string;
+
+  /**
+   * Optional PEID required for SMS delivery using Indian Carriers
+   */
+  entityId?: string;
+
+  /**
+   * Optional value corresponding to a TemplateID for SMS delivery using Indian Carriers
+   */
+  contentId?: string;
+
+  /**
    * (Optional) An application-specific hash value for the SMS workflow.
    */
   appHash?: string;

--- a/packages/verify2/lib/types/verifcationRequest.ts
+++ b/packages/verify2/lib/types/verifcationRequest.ts
@@ -6,6 +6,17 @@ import { VoiceWorkflow } from './voiceWorkflow';
 import { WhatsAppInteractiveWorkflow } from './whatsAppInteractiveWorkflow';
 import { WhatsAppWorkflow } from './whatsAppWorkflow';
 
+export type SMSWorkflowRequest = {
+  app_hash?: string;
+
+  content_id?: string;
+
+  entity_id?: string;
+} & Omit<SMSWorkflow, 'appHash'>;
+
+export type SilentAuthWorkflowRequest = {
+  redirect_url: string;
+} & Omit<SilentAuthWorkflow, 'redirectUrl'>;
 /**
  * Represents a verification request for sending verification codes via
  * different communication channels.
@@ -23,12 +34,12 @@ export type VerificationRequest = {
    */
   workflow: Array<
     | EmailWorkflow
-    | (Omit<SMSWorkflow, 'appHash'> & { app_hash: string })
-    | SilentAuthWorkflow
+    | SMSWorkflowRequest
+    | SilentAuthWorkflowRequest
     | VoiceWorkflow
     | WhatsAppInteractiveWorkflow
     | WhatsAppWorkflow
-    >;
+  >;
 
   /**
    * (Optional) The verification code to be sent.
@@ -38,7 +49,7 @@ export type VerificationRequest = {
   /**
    * (Optional) The locale for the verification request.
    */
-  locale?: VerifyLocale;
+  locale?: VerifyLocale | string;
 
   /**
    * (Optional) The timeout duration for the verification channel in seconds.

--- a/packages/verify2/lib/types/verifcationRequestParams.ts
+++ b/packages/verify2/lib/types/verifcationRequestParams.ts
@@ -28,7 +28,7 @@ export type VerificationRequestParams = {
     | VoiceWorkflow
     | WhatsAppInteractiveWorkflow
     | WhatsAppWorkflow
-    >;
+  >;
 
   /**
    * (Optional) The verification code to be sent.
@@ -38,7 +38,7 @@ export type VerificationRequestParams = {
   /**
    * (Optional) The locale for the verification request.
    */
-  locale?: VerifyLocale;
+  locale?: VerifyLocale | string;
 
   /**
    * (Optional) The timeout duration for the verification channel in seconds.

--- a/packages/verify2/lib/types/verificationResponse.ts
+++ b/packages/verify2/lib/types/verificationResponse.ts
@@ -6,4 +6,9 @@ export type VerificationResponse = {
    * The unique identifier for the verification request.
    */
   request_id: string;
+
+  /**
+   * The URL for checking the status of the verification request.
+   */
+  check_url?: string;
 };

--- a/packages/verify2/lib/verify2.ts
+++ b/packages/verify2/lib/verify2.ts
@@ -22,9 +22,7 @@ export class Verify2 extends Client {
    *  verification request.
    * @return {Request} A `Request` object containing the request ID.
    */
-  public async newRequest(
-    params: VerificationRequestParams,
-  ): Promise<Request> {
+  public async newRequest(params: VerificationRequestParams): Promise<Request> {
     const resp = await this.sendPostRequest<VerificationResponse>(
       `${this.config.apiHost}/v2/verify`,
       Client.transformers.snakeCaseObjectKeys(params, true),
@@ -32,6 +30,7 @@ export class Verify2 extends Client {
 
     return {
       requestId: resp.data.request_id,
+      checkUrl: resp.data.check_url,
     };
   }
 


### PR DESCRIPTION
Added check url to request result
Added redirect url for silent auth request
Added content id and entity id for sms request
Allowing any locale to be set along with the predefined locales
