### PR TITLE
docs: correct incorrect redirect link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ See the [Vonage Node Quickstarts repo](https://github.com/Vonage/vonage-node-cod
 
 You can find more information for each product below:
 
-* [Accounts][applications]
-* [Applications](https://github.com/Vonage/vonage-node-sdk/blob/3.x/packages/applications/README.md)
+* [Accounts][accounts]
+* [Applications][applications]
 * [Audit](https://github.com/Vonage/vonage-node-sdk/blob/3.x/packages/audit/README.md)
 * [Auth][auth]
 * [JWT][jwt]
@@ -146,6 +146,7 @@ While most of the V2 functions have been ported into their own package, some of 
 
 For more information, check out each packages migration guide.
 
+[accounts]: https://github.com/Vonage/vonage-node-sdk/blob/3.x/packages/accounts/README.md
 [applications]: https://github.com/Vonage/vonage-node-sdk/blob/3.x/packages/applications/README.md
 [auth]: https://github.com/Vonage/vonage-node-sdk/blob/3.x/packages/auth/README.md
 [sms]: https://github.com/Vonage/vonage-node-sdk/blob/3.x/packages/sms/README.md


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on the Vonage API, I noticed that there is an incorrect redirect link attached to the account section in the README.md file. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.