### PR TITLE
fix applications response types

### DIFF
--- a/packages/applications/lib/types/Application.ts
+++ b/packages/applications/lib/types/Application.ts
@@ -36,7 +36,7 @@ export type Application = {
      */
     publicKey?: string;
     /**
-     * The public key for the application.
+     * The private key for the application.
      *
      * @remarks
      * Store this value securely.

--- a/packages/applications/lib/types/Application.ts
+++ b/packages/applications/lib/types/Application.ts
@@ -35,6 +35,14 @@ export type Application = {
      *
      */
     publicKey?: string;
+    /**
+     * The public key for the application.
+     *
+     * @remarks
+     * Store this value securely.
+     *
+     */
+    privateKey?: string;
   };
 
   /**

--- a/packages/applications/lib/types/Application.ts
+++ b/packages/applications/lib/types/Application.ts
@@ -39,7 +39,7 @@ export type Application = {
      * The private key for the application.
      *
      * @remarks
-     * Store this value securely.
+     * This will only be present when the application is created, or when you cycle the public key when doing an update.
      *
      */
     privateKey?: string;

--- a/packages/applications/lib/types/CapabilityVoice.ts
+++ b/packages/applications/lib/types/CapabilityVoice.ts
@@ -35,7 +35,6 @@ export type EventCallbackUrl = {
   connectTimeout?: number;
 } & CapabilityWebhook;
 
-
 /**
  * The fallback answer url can optionally be configured. This is used when
  * answer url is offline or returning an HTTP error code.
@@ -67,17 +66,17 @@ export type CapabilityVoice = {
     /**
      * Webhook for events related to voice calls.
      */
-    eventUrl: EventCallbackUrl
+    eventUrl?: EventCallbackUrl;
 
     /**
      *  Webhook for voice call answer events.
      */
-    answerUrl: AnswerCallbackUrl
+    answerUrl?: AnswerCallbackUrl;
 
     /**
      * Webhook for fallback voice call answer events.
      */
-    fallbackAnswerUrl: FallbackAnswerUrl
+    fallbackAnswerUrl?: FallbackAnswerUrl;
   };
 
   /**

--- a/packages/applications/lib/types/CapabilityVoice.ts
+++ b/packages/applications/lib/types/CapabilityVoice.ts
@@ -62,7 +62,7 @@ export type CapabilityVoice = {
   /**
    *  Webhook configuration for voice events.
    */
-  webhooks: {
+  webhooks?: {
     /**
      * Webhook for events related to voice calls.
      */
@@ -82,14 +82,14 @@ export type CapabilityVoice = {
   /**
    * Indicates whether payment is enabled.
    */
-  paymentEnabled: boolean;
+  paymentEnabled?: boolean;
 
   /**
    * Whether to use signed webhooks for voice events.
    *
    * @remarks Refer to {@link https://developer.vonage.com/en/getting-started/concepts/webhooks#decoding-signed-webhooks} for more information.
    */
-  signedCallbacks: boolean;
+  signedCallbacks?: boolean;
 
   /**
    * Conversation TTL
@@ -97,7 +97,7 @@ export type CapabilityVoice = {
    * @remarks The length of time named conversations will remain active for after
    * creation, in hours. 0 means infinite. Maximum value is 744 (i.e., 31 days).
    */
-  conversationsTTL: number;
+  conversationsTTL?: number;
 
   /**
    * Region to round calls
@@ -108,15 +108,15 @@ export type CapabilityVoice = {
    * regional endpoint. If the call is using a regional endpoint, this will
    * override the application setting.
    */
-  region: VoiceRegions | string;
+  region?: VoiceRegions | string;
 
   /**
    * Payment gateway configuration.
    */
-  payments: {
+  payments?: {
     /**
      * List of payment gateways.
      */
-    gateways: Array<unknown>;
+    gateways?: Array<unknown>;
   };
 };

--- a/packages/applications/lib/types/Response/ApplicationResponse.ts
+++ b/packages/applications/lib/types/Response/ApplicationResponse.ts
@@ -83,5 +83,4 @@ export type ApplicationResponse = {
      */
     vbc: unknown;
   };
-} & Application &
-  APILinks;
+} & Application & APILinks;

--- a/packages/applications/lib/types/Response/ApplicationResponse.ts
+++ b/packages/applications/lib/types/Response/ApplicationResponse.ts
@@ -26,7 +26,11 @@ export type ApplicationResponse = {
     /**
      * The public key for the application.
      */
-    public_key?: string | undefined
+    public_key?: string | undefined;
+    /**
+     * The private key for the application.
+     */
+    private_key?: string | undefined;
   };
   /**
    * Privacy configuration for the application.
@@ -43,7 +47,6 @@ export type ApplicationResponse = {
    * Capabilities configuration for the application.
    */
   capabilities: {
-
     /**
      * RTC/Conversation Service related configuration.
      */
@@ -79,7 +82,6 @@ export type ApplicationResponse = {
      * programmability service applications. This is always an empty object.
      */
     vbc: unknown;
-
   };
-
-} & Application & APILinks;
+} & Application &
+  APILinks;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- `Applications` API response type is missing a `privateKey` field.
- `Applications` API does not require all the three webhook URLs to be passed during creation but the type does not allow to omit any.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR helps resolve failing type checks. The API itself works fine and has the mentioned field in its response.
Related to https://github.com/Vonage/vonage-node-sdk/issues/955.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not sure if I did things right but I ran the test suite on the PR branch.
Please, let me know if some other tests or changes are needed.

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.