### PR TITLE
feat: add more language codes for Captions API 

### DIFF
--- a/packages/video/lib/types/CaptionOptions.ts
+++ b/packages/video/lib/types/CaptionOptions.ts
@@ -5,7 +5,7 @@ export type CaptionOptions = {
   /**
    * The language code for captions (e.g., "en-us").
    */
-  languageCode?: 'en-us';
+  languageCode?: 'en-US' | 'en-AU' | 'en-GB' | 'zh-CN' | 'fr-FR' | 'fr-CA' | 'de-DE' | 'hi-IN' | 'it-IT' | 'ja-JP' | 'ko-KR' | 'pt-BR' | 'th-TH';
 
   /**
    * The maximum duration for captions.

--- a/packages/video/lib/types/CaptionOptions.ts
+++ b/packages/video/lib/types/CaptionOptions.ts
@@ -5,7 +5,7 @@ export type CaptionOptions = {
   /**
    * The language code for captions (e.g., "en-us").
    */
-  languageCode?: 'en-US' | 'en-AU' | 'en-GB' | 'zh-CN' | 'fr-FR' | 'fr-CA' | 'de-DE' | 'hi-IN' | 'it-IT' | 'ja-JP' | 'ko-KR' | 'pt-BR' | 'th-TH';
+  languageCode?: 'en-US' | 'en-AU' | 'en-GB' | 'es-US' | 'zh-CN' | 'fr-FR' | 'fr-CA' | 'de-DE' | 'hi-IN' | 'it-IT' | 'ja-JP' | 'ko-KR' | 'pt-BR' | 'th-TH';
 
   /**
    * The maximum duration for captions.


### PR DESCRIPTION
This PR adds more language codes for Captions API as it currently lists only `en-us`.
The full list is here: https://tokbox.com/developer/rest/#starting-live-captions

## Description
Not too many details can be added, just listing out more languages that are supported in the Captions API. 

## Motivation and Context
This PR adds on additional languages to the captions API. 

## Testing Details
Additional languages are supported when trying the captions API. 

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [👍 ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes.
- [n/a] All new and existing tests passed.