### PR TITLE
fix: [VIDECO-11158] Removed redundant type

### DIFF
--- a/packages/video/lib/types/ArchiveOptions.ts
+++ b/packages/video/lib/types/ArchiveOptions.ts
@@ -47,6 +47,8 @@ type BaseArchiveOptions = {
 
   /**
    * Additional properties that control the trascription output
+   * An object containing all transcription properties.
+   * Only valid if `hasTranscription` is true.
    */
   transcriptionProperties?: {
     /**
@@ -63,23 +65,6 @@ type BaseArchiveOptions = {
      * True if the archive should be transcribed.
      */
     hasTranscription?: boolean;
-
-    /**
-     * An object containing all transcription properties.
-     * Only valid if `hasTranscription` is true.
-     */
-    transcriptionProperties?: {
-      /**
-       * The primary language spoken in the archive to be transcribed, in BCP-47 format.
-       * Example: en-US, es-ES, or pt-BR.
-       */
-      primaryLanguageCode?: string;
-
-      /**
-       * True if the transcription should have a summary.
-       */
-      hasSummary?: boolean;
-    };
   }
 }
 


### PR DESCRIPTION
This pull request makes a small update to the `BaseArchiveOptions` type in `ArchiveOptions.ts`, specifically removing the transcriptionProperties from the transcriptionProperties type.


- Documentation update:
  * The comment describing `transcriptionProperties` was moved to be directly above its definition, clarifying its purpose and usage. [[1]](diffhunk://#diff-ddcefa80d1ebc54d8078abb54328cd2406b8113b2bf5e9675d425475b87caeddR50-R51) [[2]](diffhunk://#diff-ddcefa80d1ebc54d8078abb54328cd2406b8113b2bf5e9675d425475b87caeddL66-L82)<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.