### PR TITLE
chore(video): Mark getCaptionStatus as deprecated since it was never implemented in the API

### DIFF
--- a/packages/video/lib/video.ts
+++ b/packages/video/lib/video.ts
@@ -497,6 +497,7 @@ export class Video extends Client {
    *
    * @param {string} captionId - The ID of the caption to retrieve the status for.
    * @return {Promise<CaptionStatusResponse>} A promise that resolves to the status of the requested caption.
+   * @deprecated This method no longer works and was added incorrectly
    *
    * @example
    * ```ts


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Marks video::getCaptionStatus() as deprecated

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This method was added due to a bad OpenAPI spec, and was never implemented in the API itself. Marking as deprecated so users know it does not work.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and linting just to make sure nothing broke

## Example Output or Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.