### PR TITLE
fix: run build before publishing packages

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
-
-# Enable error handling
 set -e
-
 cd ./packages
-
 for package in $(ls); do
-  echo "Puiblishing $pacakge"
-  (cd "$package" && npm publish)
+  echo "Publishing $package"
+  (cd "$package" && npm run build && npm publish)
   echo "$package published"
 done
-
 echo "Publishing process completed!"


### PR DESCRIPTION
## Description
Added missing `npm run build` step to `scripts/publish.sh` before each package is published. Also fixed a typo in the script (`$pacakge` → `$package`).

## Motivation and Context
The previous release (`3.26.2`) was published without building the packages first, resulting in all 27 packages being shipped without their `dist/` artifacts. This caused an `ERR_MODULE_NOT_FOUND` crash at runtime for all consumers of the SDK.

## Testing Details
Ran `npm install` and `npm run build` from the repo root, all 27 packages built successfully with no errors. Verified with `npm publish --dry-run` on `@vonage/messages` that `dist/` artifacts are correctly included in the tarball.

**Environment:**
- Node.js: (v25.2.1)
- npm: (11.7.0)
- OS: Linux

## Example Output or Screenshots (if appropriate)
`npm publish --dry-run` confirms `dist/cjs` and `dist/esm` artifacts are present in the tarball.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document. 
  (Note: the contributing doc references `npm run compile` but the current build command is `npm run build` per root `package.json`)
- [x] All new and existing tests passed.